### PR TITLE
Dashing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Lots of things!
 - Nested types
 - Component nodes
 - Clients and services
+- Actions
 - Tests
 - Documentation
 - More examples (e.g. IoT, VB, UWP, HoloLens, etc.)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ vcs import src < ros2_dotnet_uwp.repos
 cd \dev\ament
 call install\local_setup.bat
 cd \dev\ros2
-colcon build --merge-install --packages-ignore rcl_logging_log4cxx --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
+colcon build --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
 ```
 
 Now you can just run a bunch of examples.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ vcs import src < ros2_dotnet_uwp.repos
 cd \dev\ament
 call install\local_setup.bat
 cd \dev\ros2
-colcon build --merge-install --packages-ignore rcl_logging_log4cxx --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.14393 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
+colcon build --merge-install --packages-ignore rcl_logging_log4cxx --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
 ```
 
 Now you can just run a bunch of examples.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ vcs import src < ros2_dotnet_uwp.repos
 cd \dev\ament
 call install\local_setup.bat
 cd \dev\ros2
-colcon build --merge-install --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.14393 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
+colcon build --merge-install --packages-ignore rcl_logging_log4cxx --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.14393 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
 ```
 
 Now you can just run a bunch of examples.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ What's missing?
 ---------------
 
 Lots of things!
+- Unicode types
+- String constants (specifically BoundedString)
 - Nested types
 - Component nodes
 - Clients and services

--- a/ament_dotnet_uwp.repos
+++ b/ament_dotnet_uwp.repos
@@ -2,31 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: crystal
+    version: dashing
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: crystal
+    version: dashing
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: crystal
+    version: dashing
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: crystal
+    version: dashing
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: crystal
+    version: dashing
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: crystal
+    version: dashing
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: crystal
+    version: dashing
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git

--- a/ament_dotnet_uwp.repos
+++ b/ament_dotnet_uwp.repos
@@ -2,31 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 0.5.1
+    version: crystal
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 0.5.1
+    version: crystal
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.5.2
+    version: crystal
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.5.2
+    version: crystal
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: 4b6e624e78ba3d43c1602ffc80478ee7253e0b04
+    version: crystal
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 0.1.5
-  ament/uncrustify:
+    version: crystal
+  ament/uncrustify_vendor:
     type: git
-    url: https://github.com/ament/uncrustify.git
-    version: 0.66.1
+    url: https://github.com/ament/uncrustify_vendor.git
+    version: crystal
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ variables:
 
 jobs:
 - job: 'uwp_32'
+  timeoutInMinutes: 90
   displayName: 'Build all tasks (UWP 32)'
   condition: and(succeeded(), not(variables.task), eq(variables.platform, 'uwp_32'))
   pool:
@@ -23,6 +24,7 @@ jobs:
 
 - job: 'uwp_64'
   displayName: 'Build all tasks (UWP 64)'
+  timeoutInMinutes: 90
   condition: and(succeeded(), not(variables.task), eq(variables.platform, 'uwp_64'))
   pool:
     vmImage: vs2017-win2016
@@ -34,6 +36,7 @@ jobs:
 
 - job: 'uwp_arm'
   displayName: 'Build all tasks (UWP ARM)'
+  timeoutInMinutes: 90
   condition: and(succeeded(), not(variables.task), eq(variables.platform, 'uwp_arm'))
   pool:
     vmImage: vs2017-win2016
@@ -45,6 +48,7 @@ jobs:
 
 - job: 'desktop'
   displayName: 'Build all tasks (Desktop)'
+  timeoutInMinutes: 90
   condition: and(succeeded(), not(variables.task), eq(variables.platform, 'desktop'))
   pool:
     vmImage: vs2017-win2016

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -66,6 +66,7 @@ steps:
       vcs branch
       colcon build ^
         --merge-install ^
+        --packages-ignore rcl_logging_log4cxx ^
         --cmake-args ^
           -G "${{ parameters.generator }}" ^
           -A "${{ parameters.arch }}" ^

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -93,6 +93,7 @@ steps:
       vcs branch
       colcon build ^
         --merge-install ^
+        --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx ^
         --cmake-args ^
           -G "${{ parameters.generator }}" ^
           -A "${{ parameters.arch }}" ^

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -66,7 +66,7 @@ steps:
       vcs branch
       colcon build ^
         --merge-install ^
-        --packages-ignore rcl_logging_log4cxx ^
+        --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx ^
         --cmake-args ^
           -G "${{ parameters.generator }}" ^
           -A "${{ parameters.arch }}" ^

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -72,7 +72,7 @@ steps:
           -A "${{ parameters.arch }}" ^
           -DBUILD_TESTING=OFF ^
           -DCMAKE_SYSTEM_NAME=WindowsStore ^
-          -DCMAKE_SYSTEM_VERSION=10.0.14393 ^
+          -DCMAKE_SYSTEM_VERSION=10.0.17763 ^
           -DTHIRDPARTY=ON ^
           -DINSTALL_EXAMPLES=OFF
     displayName: 'Build ros2-dotnet for UWP'

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -16,7 +16,8 @@ steps:
       catkin_pkg ^
       EmPy ^
       lark-parser ^
-      pyparsing pyyaml
+      pyparsing pyyaml ^
+      numpy
     pip install -U ^
       pytest ^
       coverage ^

--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -64,19 +64,9 @@ namespace ROS2 {
     internal static NativeRCLWaitSetInitType native_rcl_wait_set_init = null;
 
     [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-    internal delegate void NativeRCLWaitSetClearSubscriptionsType (IntPtr waitSetHandle);
+    internal delegate void NativeRCLWaitSetClearType (IntPtr waitSetHandle);
 
-    internal static NativeRCLWaitSetClearSubscriptionsType native_rcl_wait_set_clear_subscriptions = null;
-
-    [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-    internal delegate void NativeRCLWaitSetClearServicesType (IntPtr waitSetHandle);
-
-    internal static NativeRCLWaitSetClearServicesType native_rcl_wait_set_clear_services = null;
-
-    [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-    internal delegate void NativeRCLWaitSetClearClientsType (IntPtr waitSetHandle);
-
-    internal static NativeRCLWaitSetClearClientsType native_rcl_wait_set_clear_clients = null;
+    internal static NativeRCLWaitSetClearType native_rcl_wait_set_clear = null;
 
     [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
     internal delegate void NativeRCLWaitSetAddSubscriptionType (IntPtr waitSetHandle, IntPtr subscriptionHandle);
@@ -139,23 +129,11 @@ namespace ROS2 {
         (NativeRCLWaitSetInitType) Marshal.GetDelegateForFunctionPointer (
           native_rcl_wait_set_init_ptr, typeof (NativeRCLWaitSetInitType));
 
-      IntPtr native_rcl_wait_set_clear_subscriptions_ptr =
-        dllLoadUtils.GetProcAddress (pDll, "native_rcl_wait_set_clear_subscriptions");
-      RCLdotnetDelegates.native_rcl_wait_set_clear_subscriptions =
-        (NativeRCLWaitSetClearSubscriptionsType) Marshal.GetDelegateForFunctionPointer (
-          native_rcl_wait_set_clear_subscriptions_ptr, typeof (NativeRCLWaitSetClearSubscriptionsType));
-
-      IntPtr native_rcl_wait_set_clear_services_ptr =
-        dllLoadUtils.GetProcAddress (pDll, "native_rcl_wait_set_clear_services");
-      RCLdotnetDelegates.native_rcl_wait_set_clear_services =
-        (NativeRCLWaitSetClearServicesType) Marshal.GetDelegateForFunctionPointer (
-          native_rcl_wait_set_clear_services_ptr, typeof (NativeRCLWaitSetClearServicesType));
-
-      IntPtr native_rcl_wait_set_clear_clients_ptr =
-        dllLoadUtils.GetProcAddress (pDll, "native_rcl_wait_set_clear_clients");
-      RCLdotnetDelegates.native_rcl_wait_set_clear_clients =
-        (NativeRCLWaitSetClearClientsType) Marshal.GetDelegateForFunctionPointer (
-          native_rcl_wait_set_clear_clients_ptr, typeof (NativeRCLWaitSetClearClientsType));
+      IntPtr native_rcl_wait_set_clear_ptr =
+        dllLoadUtils.GetProcAddress (pDll, "native_rcl_wait_set_clear");
+      RCLdotnetDelegates.native_rcl_wait_set_clear =
+        (NativeRCLWaitSetClearType) Marshal.GetDelegateForFunctionPointer (
+          native_rcl_wait_set_clear_ptr, typeof (NativeRCLWaitSetClearType));
 
       IntPtr native_rcl_wait_set_add_subscription_ptr =
         dllLoadUtils.GetProcAddress (pDll, "native_rcl_wait_set_add_subscription");
@@ -225,16 +203,8 @@ namespace ROS2 {
         numberOfTimers, numberOfClients, numberOfServices);
     }
 
-    private static void WaitSetClearSubscriptions (IntPtr waitSetHandle) {
-      RCLdotnetDelegates.native_rcl_wait_set_clear_subscriptions (waitSetHandle);
-    }
-
-    private static void WaitSetClearServices (IntPtr waitSetHandle) {
-      RCLdotnetDelegates.native_rcl_wait_set_clear_services (waitSetHandle);
-    }
-
-    private static void WaitSetClearClients (IntPtr waitSetHandle) {
-      RCLdotnetDelegates.native_rcl_wait_set_clear_clients (waitSetHandle);
+    private static void WaitSetClear (IntPtr waitSetHandle) {
+      RCLdotnetDelegates.native_rcl_wait_set_clear (waitSetHandle);
     }
 
     private static void WaitSetAddSubscription (IntPtr waitSetHandle, IntPtr subscriptionHandle) {
@@ -288,11 +258,7 @@ namespace ROS2 {
         numberOfServices
       );
 
-      WaitSetClearSubscriptions (waitSetHandle);
-
-      WaitSetClearServices (waitSetHandle);
-
-      WaitSetClearClients (waitSetHandle);
+      WaitSetClear (waitSetHandle);
 
       foreach (ISubscriptionBase subscription in node.Subscriptions) {
         WaitSetAddSubscription (waitSetHandle, subscription.Handle);

--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -59,7 +59,7 @@ namespace ROS2 {
     internal delegate int NativeRCLWaitSetInitType (
       IntPtr waitSetHandle, long numberOfSubscriptions,
       long numberOfGuardConditions, long numberOfTimers,
-      long numberOfClients, long numberOfServices);
+      long numberOfClients, long numberOfServices, long numberOfEvents);
 
     internal static NativeRCLWaitSetInitType native_rcl_wait_set_init = null;
 
@@ -197,10 +197,11 @@ namespace ROS2 {
       long numberOfGuardConditions,
       long numberOfTimers,
       long numberOfClients,
-      long numberOfServices) {
+      long numberOfServices,
+      long numberOfEvents) {
       RCLdotnetDelegates.native_rcl_wait_set_init (
         waitSetHandle, numberOfSubscriptions, numberOfGuardConditions,
-        numberOfTimers, numberOfClients, numberOfServices);
+        numberOfTimers, numberOfClients, numberOfServices, numberOfEvents);
     }
 
     private static void WaitSetClear (IntPtr waitSetHandle) {
@@ -248,6 +249,7 @@ namespace ROS2 {
       long numberOfTimers = 0;
       long numberOfClients = 0;
       long numberOfServices = 0;
+      long numberOfEvents = 0;
 
       WaitSetInit (
         waitSetHandle,
@@ -255,7 +257,8 @@ namespace ROS2 {
         numberOfGuardConditions,
         numberOfTimers,
         numberOfClients,
-        numberOfServices
+        numberOfServices,
+        numberOfEvents
       );
 
       WaitSetClear (waitSetHandle);

--- a/rcldotnet/rcldotnet.c
+++ b/rcldotnet/rcldotnet.c
@@ -75,13 +75,14 @@ int32_t native_rcl_wait_set_init(
     long number_of_guard_conditions,
     long number_of_timers,
     long number_of_clients,
-    long number_of_services) {
+    long number_of_services,
+    long number_of_events) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   rcl_ret_t ret = rcl_wait_set_init(
       wait_set, number_of_subscriptions, number_of_guard_conditions,
       number_of_timers, number_of_clients, number_of_services,
-      rcl_get_default_allocator());
+      number_of_events, &context, rcl_get_default_allocator());
 
   return ret;
 }

--- a/rcldotnet/rcldotnet.c
+++ b/rcldotnet/rcldotnet.c
@@ -116,7 +116,7 @@ int32_t native_rcl_wait_set(void *wait_set_handle, long timeout) {
 int32_t native_rcl_take(void *subscription_handle, void *message_handle) {
   rcl_subscription_t * subscription = (rcl_subscription_t *)subscription_handle;
 
-  rcl_ret_t ret = rcl_take(subscription, message_handle, NULL);
+  rcl_ret_t ret = rcl_take(subscription, message_handle, NULL, NULL);
   return ret;
 }
 

--- a/rcldotnet/rcldotnet.h
+++ b/rcldotnet/rcldotnet.h
@@ -39,7 +39,8 @@ int32_t RCLDOTNET_CDECL native_rcl_wait_set_init(
     long numberOfGuardConditions,
     long numberOfTimers,
     long numberOfClients,
-    long numberOfServices);
+    long numberOfServices,
+    long numberOfEvents);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_wait_set_clear(void *);

--- a/rcldotnet/rcldotnet.h
+++ b/rcldotnet/rcldotnet.h
@@ -42,13 +42,7 @@ int32_t RCLDOTNET_CDECL native_rcl_wait_set_init(
     long numberOfServices);
 
 RCLDOTNET_EXPORT
-int32_t RCLDOTNET_CDECL native_rcl_wait_set_clear_subscriptions(void *);
-
-RCLDOTNET_EXPORT
-int32_t RCLDOTNET_CDECL native_rcl_wait_set_clear_services(void *);
-
-RCLDOTNET_EXPORT
-int32_t RCLDOTNET_CDECL native_rcl_wait_set_clear_clients(void *);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_clear(void *);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_wait_set_add_subscription(void *, void *);

--- a/rcldotnet/rcldotnet_publisher.c
+++ b/rcldotnet/rcldotnet_publisher.c
@@ -29,7 +29,7 @@ void native_rcl_publish(void * publisher_handle, void * raw_ros_message)
 {
   rcl_publisher_t * publisher = (rcl_publisher_t *)publisher_handle;
 
-  rcl_ret_t ret = rcl_publish(publisher, raw_ros_message);
+  rcl_ret_t ret = rcl_publish(publisher, raw_ros_message, NULL);
 
   // TODO(esteve): handle error
   if (ret != RCL_RET_OK) {

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -121,8 +121,8 @@ repositories:
     version: dashing
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/ros2-dotnet/rosidl_typesupport.git
-    version: dashing-windows
+    url: https://github.com/ros2/rosidl_typesupport.git
+    version: dashing
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -50,7 +50,7 @@ repositories:
   ros2/rcutils:
     type: git
     url: https://github.com/ros2-dotnet/rcutils.git
-    version: dashing-windows
+    version: dashing
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -2,31 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: crystal
+    version: dashing
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: crystal
+    version: dashing
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: crystal
+    version: dashing
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: crystal
+    version: dashing
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: crystal
+    version: dashing
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: crystal
+    version: dashing
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: crystal
+    version: dashing
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
@@ -34,106 +34,111 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.8
+    version: v1.0.11
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/ros2-dotnet/Fast-RTPS.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: crystal
+    version: dashing
+  ros2/rcpputils:
+    type: git
+    url: https://github.com/ros2/rcpputils.git
+    version: dashing
   ros2/rcutils:
     type: git
     url: https://github.com/ros2-dotnet/rcutils.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: crystal
+    version: dashing
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: crystal
+    version: dashing
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: crystal
+    version: dashing
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: crystal
+    version: dashing
   ros2/poco_vendor:
     type: git
     url: https://github.com/ros2/poco_vendor.git
-    version: crystal
+    version: dashing
   ros2/rcl:
     type: git
     url: https://github.com/ros2-dotnet/rcl.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: crystal
+    version: dashing
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: crystal
+    version: dashing
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: crystal
+    version: dashing
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: crystal
+    version: dashing
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: crystal
+    version: dashing
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: crystal
+    version: dashing
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: crystal
+    version: dashing
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: crystal
+    version: dashing
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: crystal
+    version: dashing
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: crystal
+    version: dashing
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: crystal
+    version: dashing
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2-dotnet/rosidl_typesupport.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: crystal
+    version: dashing
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
+    version: dashing
   ros2/tinydir_vendor:
     type: git
     url: https://github.com/ros2/tinydir_vendor.git
-    version: 1.1.0
+    version: dashing
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: 2.1.0
+    version: dashing
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
@@ -141,4 +146,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: crystal
+    version: dashing

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -146,4 +146,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: dashing
+    version: master

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -37,7 +37,7 @@ repositories:
     version: v1.0.8
   eProsima/Fast-RTPS:
     type: git
-    url: https://github.com/theseankelly/Fast-RTPS.git
+    url: https://github.com/ros2-dotnet/Fast-RTPS.git
     version: crystal-windows
   ros2/ament_cmake_ros:
     type: git
@@ -45,7 +45,7 @@ repositories:
     version: crystal
   ros2/rcutils:
     type: git
-    url: https://github.com/theseankelly/rcutils.git
+    url: https://github.com/ros2-dotnet/rcutils.git
     version: crystal-windows
   ros2/common_interfaces:
     type: git
@@ -69,7 +69,7 @@ repositories:
     version: crystal
   ros2/rcl:
     type: git
-    url: https://github.com/theseankelly/rcl.git
+    url: https://github.com/ros2-dotnet/rcl.git
     version: crystal-windows
   ros2/rcl_interfaces:
     type: git
@@ -105,7 +105,7 @@ repositories:
     version: crystal
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/theseankelly/rosidl_typesupport.git
+    url: https://github.com/ros2-dotnet/rosidl_typesupport.git
     version: crystal-windows
   ros2/rosidl_typesupport_fastrtps:
     type: git
@@ -124,7 +124,7 @@ repositories:
     version: 2.1.0
   ros2_dotnet/dotnet_cmake_module:
     type: git
-    url: https://github.com/esteve/dotnet_cmake_module.git
+    url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -49,7 +49,7 @@ repositories:
     version: dashing
   ros2/rcutils:
     type: git
-    url: https://github.com/ros2-dotnet/rcutils.git
+    url: https://github.com/ros2/rcutils.git
     version: dashing
   ros2/common_interfaces:
     type: git

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -128,5 +128,5 @@ repositories:
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git
-    url: https://github.com/theseankelly/ros2_dotnet.git
+    url: https://github.com/esteve/ros2_dotnet.git
     version: crystal

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -2,35 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 0.5.1
+    version: crystal
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 0.5.1
+    version: crystal
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.5.2
+    version: crystal
   ament/ament_package:
     type: git
-    url: https://github.com/esteve/ament_package.git
-    version: windows-escape-values
-  ament/ament_tools:
-    type: git
-    url: https://github.com/esteve/ament_tools.git
-    version: win32-platform
+    url: https://github.com/ament/ament_package.git
+    version: crystal
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: 4b6e624e78ba3d43c1602ffc80478ee7253e0b04
+    version: crystal
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 0.1.5
-  ament/uncrustify:
+    version: crystal
+  ament/uncrustify_vendor:
     type: git
-    url: https://github.com/ament/uncrustify.git
-    version: 0.66.1
+    url: https://github.com/ament/uncrustify_vendor.git
+    version: crystal
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
@@ -38,96 +34,99 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.7
+    version: v1.0.8
   eProsima/Fast-RTPS:
     type: git
-    url: https://github.com/eProsima/Fast-RTPS.git
-    version: faa62dec0f402274edea3700cf5e654b65492a42
+    url: https://github.com/theseankelly/Fast-RTPS.git
+    version: crystal-windows
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.5.0
+    version: crystal
   ros2/rcutils:
     type: git
-    url: https://github.com/ros2/rcutils.git
-    version: 0.5.1
+    url: https://github.com/theseankelly/rcutils.git
+    version: crystal-windows
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 0.5.0
+    version: crystal
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: 0.5.0
-  ros2/launch:
+    version: crystal
+  ros2/launch
     type: git
     url: https://github.com/ros2/launch.git
-    version: 0.5.2
+    version: crystal
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: 1.0.0
+    version: crystal
+  ros2/poco_vendor:
+    type: git
+    url: https://github.com/ros2/poco_vendor.git
+    version: crystal
   ros2/rcl:
     type: git
-    url: https://github.com/esteve/rcl.git
-    version: win32-stdatomic
+    url: https://github.com/theseankelly/rcl.git
+    version: crystal-windows
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: db27f0e8619460848d80c1442f7fec0c56ee63e5
-  ros2/rclpy:
+    version: crystal
+  ros2/rcl_logging:
     type: git
-    url: https://github.com/ros2/rclpy.git
-    version: 0.5.3
+    url: https://github.com/ros2/rcl_logging.git
+    version: crystal
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: 0.5.0
+    version: crystal
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 0.5.1
+    version: crystal
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 0.5.1
-  ros2/rmw_opensplice:
-    type: git
-    url: https://github.com/ros2/rmw_opensplice.git
-    version: 0.5.2
-  ros2/rosidl_typesupport_opensplice:
-    type: git
-    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
-    version: 0.5.0
-  ros2/ros2cli:
-    type: git
-    url: https://github.com/ros2/ros2cli.git
-    version: 0.5.3
+    version: crystal
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 0.5.1
+    version: crystal
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: 0.5.0
+    version: crystal
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: 0.5.0
-  ros2/rosidl_python:
-    type: git
-    url: https://github.com/ros2/rosidl_python.git
-    version: 0.5.2
+    version: crystal
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/esteve/rosidl_typesupport.git
-    version: uwp-noenv
+    url: https://github.com/theseankelly/rosidl_typesupport.git
+    version: crystal-windows
+  ros2/rosidl_typesupport_fastrtps:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+    version: crystal
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+  ros2/tinydir_vendor:
+    type: git
+    url: https://github.com/ros2/tinydir_vendor.git
+    version: 1.1.0
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: 2.1.0
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/esteve/dotnet_cmake_module.git
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git
-    url: https://github.com/esteve/ros2_dotnet.git
-    version: master
+    url: https://github.com/theseankelly/ros2_dotnet.git
+    version: crystal

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -55,7 +55,7 @@ repositories:
     type: git
     url: https://github.com/ros2/example_interfaces.git
     version: crystal
-  ros2/launch
+  ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
     version: crystal
@@ -75,6 +75,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
     version: crystal
+  ros2/rclpy:
+    type: git
+    url: https://github.com/ros2/rclpy.git
+    version: crystal
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
@@ -91,6 +95,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
     version: crystal
+  ros2/ros2cli:
+    type: git
+    url: https://github.com/ros2/ros2cli.git
+    version: crystal
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -102,6 +110,10 @@ repositories:
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
+    version: crystal
+  ros2/rosidl_python:
+    type: git
+    url: https://github.com/ros2/rosidl_python.git
     version: crystal
   ros2/rosidl_typesupport:
     type: git
@@ -128,5 +140,5 @@ repositories:
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git
-    url: https://github.com/esteve/ros2_dotnet.git
+    url: https://github.com/ros2-dotnet/ros2_dotnet.git
     version: crystal

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -92,5 +92,5 @@ repositories:
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git
-    url: https://github.com/theseankelly/ros2_dotnet.git
+    url: https://github.com/esteve/ros2_dotnet.git
     version: crystal

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -69,8 +69,8 @@ repositories:
     version: dashing
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/ros2-dotnet/rosidl_typesupport.git
-    version: dashing-windows
+    url: https://github.com/ros2/rosidl_typesupport.git
+    version: dashing
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -27,10 +27,6 @@ repositories:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
     version: crystal
-  ros2/poco_vendor:
-    type: git
-    url: https://github.com/ros2/poco_vendor.git
-    version: crystal
   ros2/rcl:
     type: git
     url: https://github.com/ros2-dotnet/rcl.git
@@ -75,17 +71,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
     version: crystal
-  ros2/test_interface_files:
-    type: git
-    url: https://github.com/ros2/test_interface_files.git
-  ros2/tinydir_vendor:
-    type: git
-    url: https://github.com/ros2/tinydir_vendor.git
-    version: 1.1.0
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: 2.1.0
+    version: crystal
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -18,7 +18,7 @@ repositories:
   ros2/rcutils:
     type: git
     url: https://github.com/ros2-dotnet/rcutils.git
-    version: dashing-windows
+    version: dashing
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -17,7 +17,7 @@ repositories:
     version: dashing
   ros2/rcutils:
     type: git
-    url: https://github.com/ros2-dotnet/rcutils.git
+    url: https://github.com/ros2/rcutils.git
     version: dashing
   ros2/common_interfaces:
     type: git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -2,79 +2,91 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.8
+    version: v1.0.11
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/ros2-dotnet/Fast-RTPS.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: crystal
+    version: dashing
+  ros2/rcpputils:
+    type: git
+    url: https://github.com/ros2/rcpputils.git
+    version: dashing
   ros2/rcutils:
     type: git
     url: https://github.com/ros2-dotnet/rcutils.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: crystal
+    version: dashing
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: crystal
+    version: dashing
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: crystal
+    version: dashing
   ros2/rcl:
     type: git
     url: https://github.com/ros2-dotnet/rcl.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: crystal
+    version: dashing
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: crystal
+    version: dashing
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: crystal
+    version: dashing
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: crystal
+    version: dashing
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: crystal
+    version: dashing
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: crystal
+    version: dashing
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: crystal
+    version: dashing
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: crystal
+    version: dashing
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2-dotnet/rosidl_typesupport.git
-    version: crystal-windows
+    version: dashing-windows
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: crystal
+    version: dashing
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: dashing
+  ros2/tinydir_vendor:
+    type: git
+    url: https://github.com/ros2/tinydir_vendor.git
+    version: dashing
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: crystal
+    version: dashing
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
@@ -82,4 +94,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: crystal
+    version: dashing

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -2,72 +2,95 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.7
+    version: v1.0.8
   eProsima/Fast-RTPS:
     type: git
-    url: https://github.com/eProsima/Fast-RTPS.git
-    version: faa62dec0f402274edea3700cf5e654b65492a42
+    url: https://github.com/theseankelly/Fast-RTPS.git
+    version: crystal-windows
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.5.0
+    version: crystal
   ros2/rcutils:
     type: git
-    url: https://github.com/ros2/rcutils.git
-    version: 0.5.1
+    url: https://github.com/theseankelly/rcutils.git
+    version: crystal-windows
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 0.5.0
+    version: crystal
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: 0.5.0
+    version: crystal
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: 1.0.0
+    version: crystal
+  ros2/poco_vendor:
+    type: git
+    url: https://github.com/ros2/poco_vendor.git
+    version: crystal
   ros2/rcl:
     type: git
-    url: https://github.com/esteve/rcl.git
-    version: win32-stdatomic
+    url: https://github.com/theseankelly/rcl.git
+    version: crystal-windows
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: db27f0e8619460848d80c1442f7fec0c56ee63e5
+    version: crystal
+  ros2/rcl_logging:
+    type: git
+    url: https://github.com/ros2/rcl_logging.git
+    version: crystal
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: 0.5.0
+    version: crystal
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 0.5.1
+    version: crystal
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 0.5.1
+    version: crystal
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 0.5.1
+    version: crystal
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: 0.5.0
+    version: crystal
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: 0.5.0
+    version: crystal
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/esteve/rosidl_typesupport.git
-    version: uwp-noenv
+    url: https://github.com/theseankelly/rosidl_typesupport.git
+    version: crystal-windows
+  ros2/rosidl_typesupport_fastrtps:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+    version: crystal
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+  ros2/tinydir_vendor:
+    type: git
+    url: https://github.com/ros2/tinydir_vendor.git
+    version: 1.1.0
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: 2.1.0
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/esteve/dotnet_cmake_module.git
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git
-    url: https://github.com/esteve/ros2_dotnet.git
-    version: master
+    url: https://github.com/theseankelly/ros2_dotnet.git
+    version: crystal

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -5,7 +5,7 @@ repositories:
     version: v1.0.8
   eProsima/Fast-RTPS:
     type: git
-    url: https://github.com/theseankelly/Fast-RTPS.git
+    url: https://github.com/ros2-dotnet/Fast-RTPS.git
     version: crystal-windows
   ros2/ament_cmake_ros:
     type: git
@@ -13,7 +13,7 @@ repositories:
     version: crystal
   ros2/rcutils:
     type: git
-    url: https://github.com/theseankelly/rcutils.git
+    url: https://github.com/ros2-dotnet/rcutils.git
     version: crystal-windows
   ros2/common_interfaces:
     type: git
@@ -33,7 +33,7 @@ repositories:
     version: crystal
   ros2/rcl:
     type: git
-    url: https://github.com/theseankelly/rcl.git
+    url: https://github.com/ros2-dotnet/rcl.git
     version: crystal-windows
   ros2/rcl_interfaces:
     type: git
@@ -69,7 +69,7 @@ repositories:
     version: crystal
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/theseankelly/rosidl_typesupport.git
+    url: https://github.com/ros2-dotnet/rosidl_typesupport.git
     version: crystal-windows
   ros2/rosidl_typesupport_fastrtps:
     type: git
@@ -88,9 +88,9 @@ repositories:
     version: 2.1.0
   ros2_dotnet/dotnet_cmake_module:
     type: git
-    url: https://github.com/esteve/dotnet_cmake_module.git
+    url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
     version: master
   ros2_dotnet/ros2_dotnet:
     type: git
-    url: https://github.com/esteve/ros2_dotnet.git
+    url: https://github.com/ros2-dotnet/ros2_dotnet.git
     version: crystal

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -94,4 +94,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: dashing
+    version: master

--- a/rosidl_generator_dotnet/bin/rosidl_generator_dotnet
+++ b/rosidl_generator_dotnet/bin/rosidl_generator_dotnet
@@ -28,16 +28,12 @@ def main(argv=sys.argv[1:]):
         required=True,
         help='The location of the file containing the generator arguments')
     parser.add_argument(
-        '--typesupport-impl',
-        required=True,
-        help='The typesupport implementation targeted by the C interface')
-    parser.add_argument(
         '--typesupport-impls',
         required=True,
         help='All the available typesupport implementations')
     args = parser.parse_args(argv)
 
-    return generate_dotnet(args.generator_arguments_file, args.typesupport_impl, args.typesupport_impls)
+    return generate_dotnet(args.generator_arguments_file, args.typesupport_impls)
 
 
 if __name__ == '__main__':

--- a/rosidl_generator_dotnet/cmake/register_dotnet.cmake
+++ b/rosidl_generator_dotnet/cmake/register_dotnet.cmake
@@ -15,7 +15,7 @@
 macro(rosidl_generator_dotnet_extras BIN GENERATOR_FILES TEMPLATE_DIR)
   find_package(ament_cmake_core QUIET REQUIRED)
   ament_register_extension(
-    "rosidl_generate_interfaces"
+    "rosidl_generate_idl_interfaces"
     "rosidl_generator_dotnet"
     "rosidl_generator_dotnet_generate_interfaces.cmake")
 

--- a/rosidl_generator_dotnet/cmake/rosidl_generator_dotnet_generate_interfaces.cmake
+++ b/rosidl_generator_dotnet/cmake/rosidl_generator_dotnet_generate_interfaces.cmake
@@ -69,6 +69,7 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
     list(APPEND _generated_srv_cs_files
       "${_output_path}/${_parent_folder}/${_module_name}.cs"
     )
+  elseif(_parent_folder STREQUAL "action")
   else()
     message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
   endif()
@@ -96,7 +97,10 @@ set(target_dependencies
   ${_dependency_files})
 foreach(dep ${target_dependencies})
   if(NOT EXISTS "${dep}")
-    message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
   endif()
 endforeach()
 

--- a/rosidl_generator_dotnet/resource/idl.c.em
+++ b/rosidl_generator_dotnet/resource/idl.c.em
@@ -1,0 +1,41 @@
+// generated from rosidl_generator_dotnet/resource/idl.c.em
+// with input from @(package_name):@(interface_path)
+// generated code does not contain a copyright notice
+@
+@#######################################################################
+@# EmPy template for generating <idl>.c files
+@#
+@# Context:
+@#  - package_name (string)
+@#  - interface_path (Path relative to the directory named after the package)
+@#  - content (IdlContent, list of elements, e.g. Messages or Services)
+@#######################################################################
+@
+@
+@#######################################################################
+@# Handle messages
+@#######################################################################
+@{
+from rosidl_parser.definition import Message
+}@
+@[for message in content.get_elements_of_type(Message)]@
+@{
+TEMPLATE(
+    'msg.c.em',
+    package_name=package_name, interface_path=interface_path, message=message)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle services
+@#######################################################################
+@
+@#TODO - services not implemented
+@
+@
+@#######################################################################
+@# Handle actions
+@#######################################################################
+@
+@#TODO - actions not implemented
+@

--- a/rosidl_generator_dotnet/resource/idl.cs.em
+++ b/rosidl_generator_dotnet/resource/idl.cs.em
@@ -1,0 +1,41 @@
+// generated from rosidl_generator_dotnet/resource/idl.cs.em
+// with input from @(package_name):@(interface_path)
+// generated code does not contain a copyright notice
+@
+@#######################################################################
+@# EmPy template for generating <idl>.cs files
+@#
+@# Context:
+@#  - package_name (string)
+@#  - interface_path (Path relative to the directory named after the package)
+@#  - content (IdlContent, list of elements, e.g. Messages or Services)
+@#######################################################################
+@
+@
+@#######################################################################
+@# Handle messages
+@#######################################################################
+@{
+from rosidl_parser.definition import Message
+}@
+@[for message in content.get_elements_of_type(Message)]@
+@{
+TEMPLATE(
+    'msg.cs.em',
+    package_name=package_name, interface_path=interface_path, message=message)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle services
+@#######################################################################
+@
+@#TODO - services not implemented
+@
+@
+@#######################################################################
+@# Handle actions
+@#######################################################################
+@
+@#TODO - actions not implemented
+@

--- a/rosidl_generator_dotnet/resource/idl.h.em
+++ b/rosidl_generator_dotnet/resource/idl.h.em
@@ -1,0 +1,41 @@
+// generated from rosidl_generator_dotnet/resource/idl.h.em
+// with input from @(package_name):@(interface_path)
+// generated code does not contain a copyright notice
+@
+@#######################################################################
+@# EmPy template for generating <idl>.h files
+@#
+@# Context:
+@#  - package_name (string)
+@#  - interface_path (Path relative to the directory named after the package)
+@#  - content (IdlContent, list of elements, e.g. Messages or Services)
+@#######################################################################
+@
+@
+@#######################################################################
+@# Handle messages
+@#######################################################################
+@{
+from rosidl_parser.definition import Message
+}@
+@[for message in content.get_elements_of_type(Message)]@
+@{
+TEMPLATE(
+    'msg.h.em',
+    package_name=package_name, interface_path=interface_path, message=message)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle services
+@#######################################################################
+@
+@# TODO - services not implemented
+@
+@
+@#######################################################################
+@# Handle actions
+@#######################################################################
+@
+@# TODO - actions not implemented
+@

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -9,8 +9,8 @@
 #include <rosidl_generator_c/string.h>
 #include <rosidl_generator_c/string_functions.h>
 
-#include <rosidl_generator_c/primitives_array.h>
-#include <rosidl_generator_c/primitives_array_functions.h>
+#include <rosidl_generator_c/primitives_sequence.h>
+#include <rosidl_generator_c/primitives_sequence_functions.h>
 
 @{
 struct_type_name = 'rcldotnet_{}_{}_{}_t'.format(spec.base_type.pkg_name, subfolder, type_name)

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -1,9 +1,28 @@
+@{
+from rosidl_generator_dotnet import msg_type_to_c
+
+from rosidl_parser.definition import AbstractNestedType
+from rosidl_parser.definition import AbstractGenericString
+from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
+from rosidl_parser.definition import AbstractSequence
+from rosidl_parser.definition import Array
+from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import NamespacedType
+
+from rosidl_cmake import convert_camel_case_to_lower_case_underscore
+
+type_name = message.structure.namespaced_type.name
+msg_typename = '%s__%s' % ('__'.join(message.structure.namespaced_type.namespaces), type_name)
+header_filename = "{0}/rcldotnet_{1}.h".format('/'.join(message.structure.namespaced_type.namespaces), convert_camel_case_to_lower_case_underscore(type_name))
+}@
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <stdint.h>
 
-#include <@(spec.base_type.pkg_name)/@(subfolder)/@(module_name).h>
+#include <@('/'.join(message.structure.namespaced_type.namespaces))/@(convert_camel_case_to_lower_case_underscore(type_name)).h>
 #include "rosidl_generator_c/message_type_support_struct.h"
 
 #include <rosidl_generator_c/string.h>
@@ -12,11 +31,6 @@
 #include <rosidl_generator_c/primitives_sequence.h>
 #include <rosidl_generator_c/primitives_sequence_functions.h>
 
-@{
-struct_type_name = 'rcldotnet_{}_{}_{}_t'.format(spec.base_type.pkg_name, subfolder, type_name)
-msg_typename = '%s__%s__%s' % (spec.base_type.pkg_name, subfolder, spec.base_type.type)
-header_filename = "{0}/{1}/rcldotnet_{2}.h".format(package_name, subfolder, convert_camel_case_to_lower_case_underscore(type_name))
-}@
 
 #include "@(header_filename)"
 
@@ -26,51 +40,52 @@ void * native_create_native_message() {
 }
 
 const void * native_get_typesupport() {
-  const void * ptr = ROSIDL_GET_MSG_TYPE_SUPPORT(@(spec.base_type.pkg_name), @(subfolder), @(spec.msg_name));
+  const void * ptr = ROSIDL_GET_MSG_TYPE_SUPPORT(@(package_name), msg, @(type_name));
   return ptr;
 }
 
-@[for field in spec.fields]@
-@[if field.type.is_primitive_type()]@
-
-@(primitive_msg_type_to_c(field.type.type)) native_read_field_@(field.name)(void * message_handle) {
-@[    if field.type.is_array]@
-@[    else]@
-@[        if field.type.is_primitive_type()]@
+@[for member in message.structure.members]@
+@[    if isinstance(member.type, Array)]@
+// TODO: Array types are not supported
+@[    elif isinstance(member.type, AbstractSequence)]@
+// TODO: Sequence types are not supported
+@[    elif isinstance(member.type, AbstractWString)]@
+// TODO: Unicode types are not supported
+@[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
+@(msg_type_to_c(member.type)) native_read_field_@(member.name)(void * message_handle) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
-@[            if field.type.type == 'string']@
-  return ros_message->@(field.name).data;
-@[            else]@
-  return ros_message->@(field.name);
-@[            end if]@
+@[        if isinstance(member.type, AbstractGenericString)]@
+  return ros_message->@(member.name).data;
 @[        else]@
+  return ros_message->@(member.name);
 @[        end if]@
-@[    end if]@
 }
-@[end if]@
-
+@[    else]@
+// TODO: Nested types are not supported
+@[    end if]@
 @[end for]@
 
-@[for field in spec.fields]@
-@[if field.type.is_primitive_type()]@
 
-void native_write_field_@(field.name)(void * message_handle, @(primitive_msg_type_to_c(field.type.type)) value) {
-@[    if field.type.is_array]@
-@[    else]@
-@[        if field.type.is_primitive_type()]@
+@[for member in message.structure.members]@
+@[    if isinstance(member.type, Array)]@
+// TODO: Array types are not supported
+@[    elif isinstance(member.type, AbstractSequence)]@
+// TODO: Sequence types are not supported
+@[    elif isinstance(member.type, AbstractWString)]@
+// TODO: Unicode types are not supported
+@[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
+void native_write_field_@(member.name)(void * message_handle, @(msg_type_to_c(member.type)) value) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
-@[            if field.type.type == 'string']@
+@[        if isinstance(member.type, AbstractGenericString)]@
   rosidl_generator_c__String__assign(
-    &ros_message->@(field.name), value);
-@[            else]@
-  ros_message->@(field.name) = value;
-@[            end if]@
+    &ros_message->@(member.name), value);
 @[        else]@
+  ros_message->@(member.name) = value;
 @[        end if]@
-@[    end if]@
 }
-@[end if]@
-
+@[    else]@
+// TODO: Nested types are not supported
+@[    end if]@
 @[end for]@
 
 void native_destroy_native_message(void * raw_ros_message) {


### PR DESCRIPTION
This PR brings the current feature set of ros2_dotnet forward to be compatible with ROS2 dashing.

High level Changes:
- Updated a couple RCL API updates
- Rebased all UWP-specific fixes in other repos onto their dashing versions
- The IDL/message generation system changed significantly in Dashing. Ported ros2_dotnet to use the new system, using rosidl_generator_python and rosidl_generator_cpp as models for best practices.

This change intentionally avoids adding any new functionality to ros2_dotnet as part of this update. Notably there is still no support for actions/services, nested types, sequence types, etc. There is also not full support for Unicode strings (new in Dashing as far as I can tell) nor BoundedString constant values.