### PR TITLE
Refactor typesupport to more closely align with rclpy and rclcpp

### DIFF
--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -34,12 +34,12 @@ header_filename = "{0}/rcldotnet_{1}.h".format('/'.join(message.structure.namesp
 
 #include "@(header_filename)"
 
-void * native_create_native_message() {
+void * @(msg_typename)__create_native_message() {
    @(msg_typename) * ros_message = @(msg_typename)__create();
    return ros_message;
 }
 
-const void * native_get_typesupport() {
+const void * @(msg_typename)__get_typesupport() {
   const void * ptr = ROSIDL_GET_MSG_TYPE_SUPPORT(@(package_name), msg, @(type_name));
   return ptr;
 }
@@ -52,7 +52,7 @@ const void * native_get_typesupport() {
 @[    elif isinstance(member.type, AbstractWString)]@
 // TODO: Unicode types are not supported
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
-@(msg_type_to_c(member.type)) native_read_field_@(member.name)(void * message_handle) {
+@(msg_type_to_c(member.type)) @(msg_typename)__read_field_@(member.name)(void * message_handle) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
 @[        if isinstance(member.type, AbstractGenericString)]@
   return ros_message->@(member.name).data;
@@ -74,7 +74,7 @@ const void * native_get_typesupport() {
 @[    elif isinstance(member.type, AbstractWString)]@
 // TODO: Unicode types are not supported
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
-void native_write_field_@(member.name)(void * message_handle, @(msg_type_to_c(member.type)) value) {
+void @(msg_typename)__write_field_@(member.name)(void * message_handle, @(msg_type_to_c(member.type)) value) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
 @[        if isinstance(member.type, AbstractGenericString)]@
   rosidl_generator_c__String__assign(
@@ -88,7 +88,7 @@ void native_write_field_@(member.name)(void * message_handle, @(msg_type_to_c(me
 @[    end if]@
 @[end for]@
 
-void native_destroy_native_message(void * raw_ros_message) {
+void @(msg_typename)__destroy_native_message(void * raw_ros_message) {
   @(msg_typename) * ros_message = raw_ros_message;
   @(msg_typename)__destroy(ros_message);
 }

--- a/rosidl_generator_dotnet/resource/msg.cs.em
+++ b/rosidl_generator_dotnet/resource/msg.cs.em
@@ -14,6 +14,7 @@ from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import NamespacedType
 
 type_name = message.structure.namespaced_type.name
+msg_typename = '%s__%s' % ('__'.join(message.structure.namespaced_type.namespaces), type_name)
 }
 using System;
 using System.Runtime.InteropServices;
@@ -34,19 +35,19 @@ public class @(type_name) : IMessage {
     static @(type_name)()
     {
         dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-        IntPtr nativelibrary = dllLoadUtils.LoadLibrary("@(package_name)_@(type_name)__rosidl_typesupport_c");
+        IntPtr nativelibrary = dllLoadUtils.LoadLibrary("@(package_name)__dotnetext");
 
-        IntPtr native_get_typesupport_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "native_get_typesupport");
+        IntPtr native_get_typesupport_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__get_typesupport");
 
         @(type_name).native_get_typesupport = (NativeGetTypeSupportType)Marshal.GetDelegateForFunctionPointer(
             native_get_typesupport_ptr, typeof(NativeGetTypeSupportType));
 
-        IntPtr native_create_native_message_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "native_create_native_message");
+        IntPtr native_create_native_message_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__create_native_message");
 
         @(type_name).native_create_native_message = (NativeCreateNativeMessageType)Marshal.GetDelegateForFunctionPointer(
             native_create_native_message_ptr, typeof(NativeCreateNativeMessageType));
 
-        IntPtr native_destroy_native_message_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "native_destroy_native_message");
+        IntPtr native_destroy_native_message_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__destroy_native_message");
 
         @(type_name).native_destroy_native_message = (NativeDestroyNativeMessageType)Marshal.GetDelegateForFunctionPointer(
             native_destroy_native_message_ptr, typeof(NativeDestroyNativeMessageType));
@@ -60,13 +61,13 @@ public class @(type_name) : IMessage {
 // TODO: Unicode types are not supported
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
         IntPtr native_read_field_@(member.name)_ptr =
-            dllLoadUtils.GetProcAddress(nativelibrary, "native_read_field_@(member.name)");
+            dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__read_field_@(member.name)");
         @(type_name).native_read_field_@(member.name) =
             (NativeReadField@(get_field_name(type_name, member.name))Type)Marshal.GetDelegateForFunctionPointer(
             native_read_field_@(member.name)_ptr, typeof(NativeReadField@(get_field_name(type_name, member.name))Type));
 
         IntPtr native_write_field_@(member.name)_ptr =
-            dllLoadUtils.GetProcAddress(nativelibrary, "native_write_field_@(member.name)");
+            dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__write_field_@(member.name)");
         @(type_name).native_write_field_@(member.name) =
             (NativeWriteField@(get_field_name(type_name, member.name))Type)Marshal.GetDelegateForFunctionPointer(
             native_write_field_@(member.name)_ptr, typeof(NativeWriteField@(get_field_name(type_name, member.name))Type));

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -10,6 +10,7 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_generator_dotnet import msg_type_to_c
 
 type_name = message.structure.namespaced_type.name
+msg_typename = '%s__%s' % ('__'.join(message.structure.namespaced_type.namespaces), type_name)
 msg_prefix = "RCLDOTNET_{0}_{1}_{2}".format(package_name, '_'.join(message.structure.namespaced_type.namespaces), type_name).upper()
 header_guard = "{0}_H".format(msg_prefix)
 }@
@@ -35,13 +36,13 @@ header_guard = "{0}_H".format(msg_prefix)
 #endif
 
 @(msg_prefix)_EXPORT
-const void * @(msg_prefix)_CDECL native_get_typesupport();
+const void * @(msg_prefix)_CDECL @(msg_typename)__get_typesupport();
 
 @(msg_prefix)_EXPORT
-void * @(msg_prefix)_CDECL native_create_native_message();
+void * @(msg_prefix)_CDECL @(msg_typename)__create_native_message();
 
 @(msg_prefix)_EXPORT
-void @(msg_prefix)_CDECL native_destroy_native_message(void *);
+void @(msg_prefix)_CDECL @(msg_typename)__destroy_native_message(void *);
 
 @[for member in message.structure.members]@
 @[    if isinstance(member.type, Array)]@
@@ -52,10 +53,10 @@ void @(msg_prefix)_CDECL native_destroy_native_message(void *);
 // TODO: Unicode types are not supported
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
 @(msg_prefix)_EXPORT
-@(msg_type_to_c(member.type)) @(msg_prefix)_CDECL native_read_field_@(member.name)(void *);
+@(msg_type_to_c(member.type)) @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);
 
 @(msg_prefix)_EXPORT
-void native_write_field_@(member.name)(void *, @(msg_type_to_c(member.type)));
+void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.type)));
 
 @[    end if]@
 @[end for]@

--- a/rosidl_generator_dotnet/rosidl_generator_dotnet/__init__.py
+++ b/rosidl_generator_dotnet/rosidl_generator_dotnet/__init__.py
@@ -43,18 +43,10 @@ class Underscorer(string.Formatter):
 def generate_dotnet(generator_arguments_file, typesupport_impls):
     mapping = {
         'idl.cs.em': '%s.cs',
+        'idl.c.em': '%s.c',
         'idl.h.em': 'rcldotnet_%s.h'
     }
     generate_files(generator_arguments_file, mapping)
-
-    typesupport_impls = typesupport_impls.split(';')
-    for impl in typesupport_impls:
-        typesupport_mapping = {
-            'idl.c.em' : '%s.ep.{0}.c'.format(impl)
-        }
-        generate_files(generator_arguments_file, typesupport_mapping)
-
-
     return 0
 
 


### PR DESCRIPTION
(**NOTE**: This PR is based on top of PR #40 -- In the changelog below, commit 57c14fb is the only one relevant to this particular issue.)

The current typesupport generation code produces quite a bit of output. There's one DLL per field within each message, times the number of available typesupports. Most importantly, I encountered naming collisions for dlls/packages when a package contains a message and service (for example) by the same name.

This change attempts to align the ros2_dotnet handling of typesupport to more closely align with how other official generators (cpp, python) handle it. Specifically:
- Produce single typesupport dll for package, not per-message.

- Only target C typesupport (others were unused and identical)
- Clean up cmake and adopt patterns found in rosidl_generator_py where
possible