### PR TITLE
[eloquent] Fix 'xyz__rosidl_generator_c' was not found before

### DIFF
--- a/rosidl_generator_dotnet/cmake/rosidl_generator_dotnet_generate_interfaces.cmake
+++ b/rosidl_generator_dotnet/cmake/rosidl_generator_dotnet_generate_interfaces.cmake
@@ -255,11 +255,11 @@ foreach(_generated_c_ts_file ${_generated_c_ts_files})
 
   add_dependencies(${_target_name}
     ${rosidl_generate_interfaces_TARGET}__${_typesupport_impl}
+    ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
   )
   ament_target_dependencies(${_target_name}
     "rosidl_generator_c"
     "rosidl_generator_dotnet"
-    "${PROJECT_NAME}__rosidl_generator_c"
   )
 
   if(NOT rosidl_generate_interfaces_SKIP_INSTALL)


### PR DESCRIPTION
When I try to build `std_msgs` with `rosidl_generator_dotnet`, I saw the following error:

```
--- stderr: std_msgs
CMake Error at C:/Users/tzuhs/Miniconda3/envs/ros-eloquent-ros-base/Library/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:52 (message):
  ament_target_dependencies() the passed package name
  'std_msgs__rosidl_generator_c' was not found before
Call Stack (most recent call first):
  C:/Users/tzuhs/Miniconda3/envs/ros-eloquent-ros-base/Library/share/rosidl_generator_dotnet/cmake/rosidl_generator_dotnet_generate_interfaces.cmake:260 (ament_target_dependencies)
  C:/Users/tzuhs/Miniconda3/envs/ros-eloquent-ros-base/Library/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:49 (include)
  C:/Users/tzuhs/Miniconda3/envs/ros-eloquent-ros-base/Library/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  CMakeLists.txt:49 (rosidl_generate_interfaces)
```

It turned out the `ament_target_dependencies` depending on a target instead of a package, and move the target to `add_dependencies`.

P.S. I am not sure if it is a `eloquent`-only issue.