### PR TITLE
Eloquent support

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -34,6 +34,8 @@ jobs:
         cd \dev\ros2
         copy ${{github.workspace}}\ros2_dotnet.repos .
         vcs import src < ros2_dotnet.repos
+        rd /s /q src\ros2_dotnet\ros2_dotnet
+        xcopy /e /i ${{github.workspace}} src\ros2_dotnet\ros2_dotnet
         vcs branch
       shell: cmd
 
@@ -42,7 +44,7 @@ jobs:
         TARGET_ARCH: ${{ matrix.arch }}
       run: |
         cd \dev\ros2
-        colcon build --event-handlers console_cohesion+ console_package_list+ --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
+        colcon build --event-handlers console_cohesion+ console_package_list+ --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace ros2lifecycle_test_fixtures --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
       shell: cmd
 
     - name: Compress ROS2 install directory

--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -42,7 +42,7 @@ jobs:
         TARGET_ARCH: ${{ matrix.arch }}
       run: |
         cd \dev\ros2
-        colcon build --event-handlers console_cohesion+ console_package_list+ --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF
+        colcon build --event-handlers console_cohesion+ console_package_list+ --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
       shell: cmd
 
     - name: Compress ROS2 install directory

--- a/.github/workflows/build_uwp.yml
+++ b/.github/workflows/build_uwp.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         cd \dev\ros2
         call ..\ament\install\local_setup.bat
-        colcon build --event-handlers console_cohesion+ console_package_list+ --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
+        colcon build --event-handlers console_cohesion+ console_package_list+ --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.18362 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
       shell: cmd
 
     - name: Compress ROS2 install directory

--- a/.github/workflows/build_uwp.yml
+++ b/.github/workflows/build_uwp.yml
@@ -9,7 +9,7 @@ jobs:
   build-uwp:
     strategy:
       matrix:
-        arch: [x64, Win32, ARM]
+        arch: [x64, Win32]
     runs-on: windows-latest
     env:
       VisualStudioVersion: '16.0'

--- a/.github/workflows/build_uwp.yml
+++ b/.github/workflows/build_uwp.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         cd \dev\ros2
         call ..\ament\install\local_setup.bat
-        colcon build --event-handlers console_cohesion+ console_package_list+ --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF
+        colcon build --event-handlers console_cohesion+ console_package_list+ --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace --cmake-args -A %TARGET_ARCH% -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
       shell: cmd
 
     - name: Compress ROS2 install directory

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ vcs import src < ros2_dotnet_uwp.repos
 cd \dev\ament
 call install\local_setup.bat
 cd \dev\ros2
-colcon build --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF
+colcon build --merge-install --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx rcl_logging_spdlog ros2trace tracetools_launch tracetools_read tracetools_test tracetools_trace --cmake-args -A "%TARGET_ARCH%" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.17763 -DTHIRDPARTY=ON -DINSTALL_EXAMPLES=OFF -DBUILD_TESTING=OFF -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
 ```
 
 Now you can just run a bunch of examples.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Build status
 
 | Target | Status |
 |----------|--------|
-| **Universal Windows Platform (x86/x64/ARM)** | ![Build (UWP)](https://github.com/ros2-dotnet/ros2_dotnet/workflows/Build%20(UWP)/badge.svg) |
+| **Universal Windows Platform (x86/x64)** | ![Build (UWP)](https://github.com/ros2-dotnet/ros2_dotnet/workflows/Build%20(UWP)/badge.svg) |
 | **Windows Desktop (x64)** | ![Build (Desktop)](https://github.com/ros2-dotnet/ros2_dotnet/workflows/Build%20(Desktop)/badge.svg) |
 | **Linux** | (TODO) |
 
@@ -89,7 +89,7 @@ call install\local_setup.bat
 UWP
 ---
 
-Replace `%TARGET_ARCH%` with Win32, x64 or ARM
+Replace `%TARGET_ARCH%` with Win32 or x64
 
 ```
 md \dev\ros2\src

--- a/ament_dotnet_uwp.repos
+++ b/ament_dotnet_uwp.repos
@@ -2,31 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: dashing
+    version: eloquent
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: dashing
+    version: eloquent
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: dashing
+    version: eloquent
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: dashing
+    version: eloquent
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: dashing
+    version: ros2
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: dashing
+    version: eloquent
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: dashing
+    version: eloquent
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -68,6 +68,8 @@ steps:
       colcon build ^
         --merge-install ^
         --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx ^
+          rcl_logging_spdlog ros2trace tracetools_launch tracetools_read ^
+          tracetools_test tracetools_trace ^
         --cmake-args ^
           -G "${{ parameters.generator }}" ^
           -A "${{ parameters.arch }}" ^
@@ -75,7 +77,8 @@ steps:
           -DCMAKE_SYSTEM_NAME=WindowsStore ^
           -DCMAKE_SYSTEM_VERSION=10.0.17763 ^
           -DTHIRDPARTY=ON ^
-          -DINSTALL_EXAMPLES=OFF
+          -DINSTALL_EXAMPLES=OFF ^
+          -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
     displayName: 'Build ros2-dotnet for UWP'
 
 - ${{ if eq(parameters.platform, 'desktop') }}:
@@ -95,12 +98,15 @@ steps:
       colcon build ^
         --merge-install ^
         --packages-ignore rmw_fastrtps_dynamic_cpp rcl_logging_log4cxx ^
+          rcl_logging_spdlog ros2trace tracetools_launch tracetools_read ^
+          tracetools_test tracetools_trace ^
         --cmake-args ^
           -G "${{ parameters.generator }}" ^
           -A "${{ parameters.arch }}" ^
           -DBUILD_TESTING=OFF ^
           -DTHIRDPARTY=ON ^
-          -DINSTALL_EXAMPLES=OFF
+          -DINSTALL_EXAMPLES=OFF ^
+          -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop
     displayName: 'Build ros2-dotnet for Desktop'
 
   - script: |

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -2,31 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: dashing
+    version: eloquent
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: dashing
+    version: eloquent
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: dashing
+    version: eloquent
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: dashing
+    version: eloquent
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: dashing
+    version: ros2
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: dashing
+    version: eloquent
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: dashing
+    version: eloquent
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
@@ -38,107 +38,115 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/ros2-dotnet/Fast-RTPS.git
-    version: dashing-windows
+    version: eloquent-windows
+  eProsima/foonathan_memory_vendor:
+    type: git
+    url: https://github.com/eProsima/foonathan_memory_vendor.git
+    version: master
+  micro-ROS/ros_tracing/ros2_tracing:
+    type: git
+    url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+    version: 0.2.10
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: dashing
+    version: eloquent
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: dashing
+    version: eloquent
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: dashing
+    version: eloquent
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: dashing
+    version: eloquent
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: dashing
+    version: eloquent
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: dashing
+    version: eloquent
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: dashing
+    version: eloquent
   ros2/poco_vendor:
     type: git
     url: https://github.com/ros2/poco_vendor.git
-    version: dashing
+    version: eloquent
   ros2/rcl:
     type: git
-    url: https://github.com/ros2-dotnet/rcl.git
-    version: dashing-windows
+    url: https://github.com/ros2/rcl.git
+    version: eloquent
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: dashing
+    version: eloquent
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: dashing
+    version: eloquent
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: dashing
+    version: eloquent
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: dashing
+    version: eloquent
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: dashing
+    version: eloquent
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: dashing
+    version: eloquent
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: dashing
+    version: eloquent
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/ros2/rosidl_typesupport.git
-    version: dashing
+    url: https://github.com/ros2-dotnet/rosidl_typesupport.git
+    version: eloquent-windows
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: dashing
+    version: eloquent
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: dashing
+    version: eloquent
   ros2/tinydir_vendor:
     type: git
     url: https://github.com/ros2/tinydir_vendor.git
-    version: dashing
+    version: eloquent
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: dashing
+    version: eloquent
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git

--- a/ros2_dotnet.repos
+++ b/ros2_dotnet.repos
@@ -79,6 +79,10 @@ repositories:
     type: git
     url: https://github.com/ros2/poco_vendor.git
     version: eloquent
+  ros2/python_cmake_module:
+    type: git
+    url: https://github.com/ros2/python_cmake_module.git
+    version: eloquent
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -6,87 +6,95 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/ros2-dotnet/Fast-RTPS.git
-    version: dashing-windows
+    version: eloquent-windows
+  eProsima/foonathan_memory_vendor:
+    type: git
+    url: https://github.com/eProsima/foonathan_memory_vendor.git
+    version: master
+  micro-ROS/ros_tracing/ros2_tracing:
+    type: git
+    url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+    version: 0.2.10
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: dashing
+    version: eloquent
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: dashing
+    version: eloquent
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: dashing
+    version: eloquent
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: dashing
+    version: eloquent
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: dashing
+    version: eloquent
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: dashing
+    version: eloquent
   ros2/rcl:
     type: git
-    url: https://github.com/ros2-dotnet/rcl.git
-    version: dashing-windows
+    url: https://github.com/ros2/rcl.git
+    version: eloquent
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: dashing
+    version: eloquent
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: dashing
+    version: eloquent
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: dashing
+    version: eloquent
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: dashing
+    version: eloquent
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: dashing
+    version: eloquent
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: dashing
+    version: eloquent
   ros2/rosidl_typesupport:
     type: git
-    url: https://github.com/ros2/rosidl_typesupport.git
-    version: dashing
+    url: https://github.com/ros2-dotnet/rosidl_typesupport.git
+    version: eloquent-windows
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: dashing
+    version: eloquent
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: dashing
+    version: eloquent
   ros2/tinydir_vendor:
     type: git
     url: https://github.com/ros2/tinydir_vendor.git
-    version: dashing
+    version: eloquent
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: dashing
+    version: eloquent
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git


### PR DESCRIPTION
Porting project forward to Eloquent.

Fortunately no code changes to the core of `ros2_dotnet` were required; only some updates to repos, an update to the repos files, and updated build instructions.

This PR depends on the completion of #41 which should be merged first. I will rebase this PR once that happens.
