### PR TITLE
Add support for collections and other array/collections improvements

### DIFF
--- a/rcldotnet/test/test_messages.cs
+++ b/rcldotnet/test/test_messages.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime;
 using System.Runtime.InteropServices;
@@ -217,17 +218,17 @@ namespace RCLdotnetTests
       ISubscription<test_msgs.msg.Arrays> chatter_sub = node_array_2.CreateSubscription<test_msgs.msg.Arrays> (
         "topic_array", rcv_msg =>
         {
-          received=true;
-          msg2 = rcv_msg;
+            received = true;
+            msg2 = rcv_msg;
         }
       );
 
-      while(!received)
+      while (!received)
       {
-        chatter_pub.Publish (msg);
+          chatter_pub.Publish(msg);
 
-        RCLdotnet.SpinOnce(node_array_1, 500);
-        RCLdotnet.SpinOnce(node_array_2, 500);
+          RCLdotnet.SpinOnce(node_array_1, 500);
+          RCLdotnet.SpinOnce(node_array_2, 500);
       }
 
       // bool_values
@@ -299,7 +300,7 @@ namespace RCLdotnetTests
       Assert.Equal(24, msg2.Int32_values[0]);
       Assert.Equal(25, msg2.Int32_values[1]);
       Assert.Equal(26, msg2.Int32_values[2]);
-      
+
       // uint32_values
       Assert.Equal(3, test_msgs.msg.Arrays.Uint32_values_Length);
       Assert.Equal(3, msg2.Uint32_values.Length);
@@ -313,7 +314,7 @@ namespace RCLdotnetTests
       Assert.Equal(30, msg2.Int64_values[0]);
       Assert.Equal(31, msg2.Int64_values[1]);
       Assert.Equal(32, msg2.Int64_values[2]);
-      
+
       // uint64_values
       Assert.Equal(3, test_msgs.msg.Arrays.Uint64_values_Length);
       Assert.Equal(3, msg2.Uint64_values.Length);
@@ -359,7 +360,7 @@ namespace RCLdotnetTests
       Assert.Equal((uint)57, msg2.Basic_types_values[1].Uint32_value);
       Assert.Equal(58, msg2.Basic_types_values[1].Int64_value);
       Assert.Equal((ulong)59, msg2.Basic_types_values[1].Uint64_value);
- 
+
       Assert.True(msg2.Basic_types_values[2].Bool_value);
       Assert.Equal(60, msg2.Basic_types_values[2].Byte_value);
       Assert.Equal(61, msg2.Basic_types_values[2].Char_value);
@@ -373,6 +374,44 @@ namespace RCLdotnetTests
       Assert.Equal((uint)69, msg2.Basic_types_values[2].Uint32_value);
       Assert.Equal(70, msg2.Basic_types_values[2].Int64_value);
       Assert.Equal((ulong)71, msg2.Basic_types_values[2].Uint64_value);
+    }
+
+    [Fact]
+    public void TestPublishArraysSizeCheckToLittle()
+    {
+      RCLdotnet.Init();
+      var nodeArraysSizeCheck = RCLdotnet.CreateNode("test_arrays_size_check_to_little");
+      var chatterPub = nodeArraysSizeCheck.CreatePublisher<test_msgs.msg.Arrays>("topic_array_size_check_to_little");
+      
+      var msg = new test_msgs.msg.Arrays();
+      msg.Bool_values = new bool[]
+      {
+        false,
+        true,
+      };
+      
+      var exception = Assert.Throws<Exception>(() => chatterPub.Publish(msg));
+      Assert.Equal("Invalid size of array 'Bool_values'.", exception.Message);
+    }
+
+    [Fact]
+    public void TestPublishArraysSizeCheckToMuch()
+    {
+      RCLdotnet.Init();
+      var nodeArraysSizeCheck = RCLdotnet.CreateNode("test_arrays_size_check_to_much");
+      var chatterPub = nodeArraysSizeCheck.CreatePublisher<test_msgs.msg.Arrays>("topic_array_size_check_to_much");
+
+      var msg = new test_msgs.msg.Arrays();
+      msg.String_values = new string[]
+      {
+        "0",
+        "1",
+        "2",
+        "3",
+      };
+      
+      var exception = Assert.Throws<Exception>(() => chatterPub.Publish(msg));
+      Assert.Equal("Invalid size of array 'String_values'.", exception.Message);
     }
 
     [Fact]
@@ -938,6 +977,26 @@ namespace RCLdotnetTests
       Assert.Equal((uint)69, msg2.Basic_types_values[2].Uint32_value);
       Assert.Equal(70, msg2.Basic_types_values[2].Int64_value);
       Assert.Equal((ulong)71, msg2.Basic_types_values[2].Uint64_value);
+    }
+
+    [Fact]
+    public void TestPublishBoundedSequencesSizeCheck()
+    {
+      RCLdotnet.Init();
+      var nodeBoundedSequencesSizeCheck = RCLdotnet.CreateNode("test_bounded_sequences_size_check");
+      var chatterPub = nodeBoundedSequencesSizeCheck.CreatePublisher<test_msgs.msg.BoundedSequences>("topic_bounded_sequences_size_check");
+
+      var msg = new test_msgs.msg.BoundedSequences();
+      msg.String_values = new List<string>
+      {
+        "0",
+        "1",
+        "2",
+        "3",
+      };
+      
+      var exception = Assert.Throws<Exception>(() => chatterPub.Publish(msg));
+      Assert.Equal("Invalid size of bounded sequence 'String_values'.", exception.Message);
     }
   }
 }

--- a/rcldotnet/test/test_messages.cs
+++ b/rcldotnet/test/test_messages.cs
@@ -230,75 +230,104 @@ namespace RCLdotnetTests
       }
 
       // bool_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Bool_values_Count);
+      Assert.Equal(3, msg2.Bool_values.Count);
       Assert.True(msg2.Bool_values[0]);
       Assert.False(msg2.Bool_values[1]);
       Assert.True(msg2.Bool_values[2]);
 
       // byte_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Byte_values_Count);
+      Assert.Equal(3, msg2.Byte_values.Count);
       Assert.Equal(0, msg2.Byte_values[0]);
       Assert.Equal(1, msg2.Byte_values[1]);
       Assert.Equal(2, msg2.Byte_values[2]);
 
       // char_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Char_values_Count);
+      Assert.Equal(3, msg2.Char_values.Count);
       Assert.Equal(3, msg2.Char_values[0]);
       Assert.Equal(4, msg2.Char_values[1]);
       Assert.Equal(5, msg2.Char_values[2]);
 
       // float32_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Float32_values_Count);
+      Assert.Equal(3, msg2.Float32_values.Count);
       Assert.Equal(6.1f, msg2.Float32_values[0]);
       Assert.Equal(7.1f, msg2.Float32_values[1]);
       Assert.Equal(8.1f, msg2.Float32_values[2]);
 
       // float64_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Float64_values_Count);
+      Assert.Equal(3, msg2.Float64_values.Count);
       Assert.Equal(9.1, msg2.Float64_values[0]);
       Assert.Equal(10.1, msg2.Float64_values[1]);
       Assert.Equal(11.1, msg2.Float64_values[2]);
 
       // int8_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Int8_values_Count);
+      Assert.Equal(3, msg2.Int8_values.Count);
       Assert.Equal(12, msg2.Int8_values[0]);
       Assert.Equal(13, msg2.Int8_values[1]);
       Assert.Equal(14, msg2.Int8_values[2]);
 
       // uint8_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint8_values_Count);
+      Assert.Equal(3, msg2.Uint8_values.Count);
       Assert.Equal(15, msg2.Uint8_values[0]);
       Assert.Equal(16, msg2.Uint8_values[1]);
       Assert.Equal(17, msg2.Uint8_values[2]);
 
       // int16_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Int16_values_Count);
+      Assert.Equal(3, msg2.Int16_values.Count);
       Assert.Equal(18, msg2.Int16_values[0]);
       Assert.Equal(19, msg2.Int16_values[1]);
       Assert.Equal(20, msg2.Int16_values[2]);
 
       // uint16_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint16_values_Count);
+      Assert.Equal(3, msg2.Uint16_values.Count);
       Assert.Equal(21, msg2.Uint16_values[0]);
       Assert.Equal(22, msg2.Uint16_values[1]);
       Assert.Equal(23, msg2.Uint16_values[2]);
 
       // int32_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Int32_values_Count);
+      Assert.Equal(3, msg2.Int32_values.Count);
       Assert.Equal(24, msg2.Int32_values[0]);
       Assert.Equal(25, msg2.Int32_values[1]);
       Assert.Equal(26, msg2.Int32_values[2]);
       
       // uint32_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint32_values_Count);
+      Assert.Equal(3, msg2.Uint32_values.Count);
       Assert.Equal((uint)27, msg2.Uint32_values[0]);
       Assert.Equal((uint)28, msg2.Uint32_values[1]);
       Assert.Equal((uint)29, msg2.Uint32_values[2]);
 
       // int64_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Int64_values_Count);
+      Assert.Equal(3, msg2.Int64_values.Count);
       Assert.Equal(30, msg2.Int64_values[0]);
       Assert.Equal(31, msg2.Int64_values[1]);
       Assert.Equal(32, msg2.Int64_values[2]);
       
       // uint64_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint64_values_Count);
+      Assert.Equal(3, msg2.Uint64_values.Count);
       Assert.Equal((ulong)33, msg2.Uint64_values[0]);
       Assert.Equal((ulong)34, msg2.Uint64_values[1]);
       Assert.Equal((ulong)35, msg2.Uint64_values[2]);
 
       // string_values
+      Assert.Equal(3, test_msgs.msg.Arrays.String_values_Count);
+      Assert.Equal(3, msg2.String_values.Count);
       Assert.Equal("one", msg2.String_values[0]);
       Assert.Equal("two", msg2.String_values[1]);
       Assert.Equal("three", msg2.String_values[2]);
       
+      Assert.Equal(3, test_msgs.msg.Arrays.Basic_types_values_Count);
       Assert.Equal(3, msg2.Basic_types_values.Count);
       Assert.True(msg2.Basic_types_values[0].Bool_value);
       Assert.Equal(36, msg2.Basic_types_values[0].Byte_value);

--- a/rcldotnet/test/test_messages.cs
+++ b/rcldotnet/test/test_messages.cs
@@ -86,8 +86,8 @@ namespace RCLdotnetTests
     public void TestPublishArrays()
     {
       RCLdotnet.Init ();
-      INode node_array_1 = RCLdotnet.CreateNode ("test_string_1");
-      INode node_array_2 = RCLdotnet.CreateNode ("test_string_2");
+      INode node_array_1 = RCLdotnet.CreateNode ("test_arrays_1");
+      INode node_array_2 = RCLdotnet.CreateNode ("test_arrays_2");
       IPublisher<test_msgs.msg.Arrays> chatter_pub = node_array_1.CreatePublisher<test_msgs.msg.Arrays> ("topic_array");
 
       test_msgs.msg.Arrays msg = new test_msgs.msg.Arrays ();
@@ -372,5 +372,569 @@ namespace RCLdotnetTests
       Assert.Equal((ulong)71, msg2.Basic_types_values[2].Uint64_value);
     }
 
+    [Fact]
+    public void TestPublishUnboundedSequences()
+    {
+      RCLdotnet.Init();
+      INode node_array_1 = RCLdotnet.CreateNode("test_unbounded_sequences_1");
+      INode node_array_2 = RCLdotnet.CreateNode("test_unbounded_sequences_2");
+      IPublisher<test_msgs.msg.UnboundedSequences> chatter_pub = node_array_1.CreatePublisher<test_msgs.msg.UnboundedSequences>("topic_unbounded_sequences");
+
+      test_msgs.msg.UnboundedSequences msg = new test_msgs.msg.UnboundedSequences();
+      test_msgs.msg.UnboundedSequences msg2 = new test_msgs.msg.UnboundedSequences();
+
+      // bool_values
+      msg.Bool_values.Add(true);
+      msg.Bool_values.Add(false);
+      msg.Bool_values.Add(true);
+
+      // byte_values
+      msg.Byte_values.Add(0);
+      msg.Byte_values.Add(1);
+      msg.Byte_values.Add(2);
+
+      // char_values
+      msg.Char_values.Add(3);
+      msg.Char_values.Add(4);
+      msg.Char_values.Add(5);
+
+      // float32_values
+      msg.Float32_values.Add(6.1f);
+      msg.Float32_values.Add(7.1f);
+      msg.Float32_values.Add(8.1f);
+
+      // float64_values
+      msg.Float64_values.Add(9.1);
+      msg.Float64_values.Add(10.1);
+      msg.Float64_values.Add(11.1);
+
+      // int8_values
+      msg.Int8_values.Add(12);
+      msg.Int8_values.Add(13);
+      msg.Int8_values.Add(14);
+
+      // uint8_values
+      msg.Uint8_values.Add(15);
+      msg.Uint8_values.Add(16);
+      msg.Uint8_values.Add(17);
+
+      // int16_values
+      msg.Int16_values.Add(18);
+      msg.Int16_values.Add(19);
+      msg.Int16_values.Add(20);
+
+      // uint16_values
+      msg.Uint16_values.Add(21);
+      msg.Uint16_values.Add(22);
+      msg.Uint16_values.Add(23);
+
+      // int32_values
+      msg.Int32_values.Add(24);
+      msg.Int32_values.Add(25);
+      msg.Int32_values.Add(26);
+
+      // uint32_values
+      msg.Uint32_values.Add(27);
+      msg.Uint32_values.Add(28);
+      msg.Uint32_values.Add(29);
+
+      // int64_values
+      msg.Int64_values.Add(30);
+      msg.Int64_values.Add(31);
+      msg.Int64_values.Add(32);
+
+      // uint64_values
+      msg.Uint64_values.Add(33);
+      msg.Uint64_values.Add(34);
+      msg.Uint64_values.Add(35);
+
+      // string_values
+      msg.String_values.Add("one");
+      msg.String_values.Add("two");
+      msg.String_values.Add("three");
+
+      test_msgs.msg.BasicTypes basic_type_1 = new test_msgs.msg.BasicTypes();
+      basic_type_1.Bool_value = true;
+      basic_type_1.Byte_value = 36;
+      basic_type_1.Char_value = 37;
+      basic_type_1.Float32_value = 38.1f;
+      basic_type_1.Float64_value = 39.1;
+      basic_type_1.Int8_value = 40;
+      basic_type_1.Uint8_value = 41;
+      basic_type_1.Int16_value = 42;
+      basic_type_1.Uint16_value = 43;
+      basic_type_1.Int32_value = 44;
+      basic_type_1.Uint32_value = 45;
+      basic_type_1.Int64_value = 46;
+      basic_type_1.Uint64_value = 47;
+
+      test_msgs.msg.BasicTypes basic_type_2 = new test_msgs.msg.BasicTypes();
+      basic_type_2.Bool_value = false;
+      basic_type_2.Byte_value = 48;
+      basic_type_2.Char_value = 49;
+      basic_type_2.Float32_value = 50.1f;
+      basic_type_2.Float64_value = 51.1;
+      basic_type_2.Int8_value = 52;
+      basic_type_2.Uint8_value = 53;
+      basic_type_2.Int16_value = 54;
+      basic_type_2.Uint16_value = 55;
+      basic_type_2.Int32_value = 56;
+      basic_type_2.Uint32_value = 57;
+      basic_type_2.Int64_value = 58;
+      basic_type_2.Uint64_value = 59;
+
+      test_msgs.msg.BasicTypes basic_type_3 = new test_msgs.msg.BasicTypes();
+      basic_type_3.Bool_value = true;
+      basic_type_3.Byte_value = 60;
+      basic_type_3.Char_value = 61;
+      basic_type_3.Float32_value = 62.1f;
+      basic_type_3.Float64_value = 63.1;
+      basic_type_3.Int8_value = 64;
+      basic_type_3.Uint8_value = 65;
+      basic_type_3.Int16_value = 66;
+      basic_type_3.Uint16_value = 67;
+      basic_type_3.Int32_value = 68;
+      basic_type_3.Uint32_value = 69;
+      basic_type_3.Int64_value = 70;
+      basic_type_3.Uint64_value = 71;
+
+      msg.Basic_types_values.Add(basic_type_1);
+      msg.Basic_types_values.Add(basic_type_2);
+      msg.Basic_types_values.Add(basic_type_3);
+
+      bool received=false;
+      ISubscription<test_msgs.msg.UnboundedSequences> chatter_sub = node_array_2.CreateSubscription<test_msgs.msg.UnboundedSequences>(
+        "topic_unbounded_sequences", rcv_msg =>
+        {
+          received=true;
+          msg2 = rcv_msg;
+        }
+      );
+
+      while(!received)
+      {
+        chatter_pub.Publish(msg);
+
+        RCLdotnet.SpinOnce(node_array_1, 500);
+        RCLdotnet.SpinOnce(node_array_2, 500);
+      }
+
+      // bool_values
+      Assert.Equal(3, msg2.Bool_values.Count);
+      Assert.True(msg2.Bool_values[0]);
+      Assert.False(msg2.Bool_values[1]);
+      Assert.True(msg2.Bool_values[2]);
+
+      // byte_values
+      Assert.Equal(3, msg2.Byte_values.Count);
+      Assert.Equal(0, msg2.Byte_values[0]);
+      Assert.Equal(1, msg2.Byte_values[1]);
+      Assert.Equal(2, msg2.Byte_values[2]);
+
+      // char_values
+      Assert.Equal(3, msg2.Char_values.Count);
+      Assert.Equal(3, msg2.Char_values[0]);
+      Assert.Equal(4, msg2.Char_values[1]);
+      Assert.Equal(5, msg2.Char_values[2]);
+
+      // float32_values
+      Assert.Equal(3, msg2.Float32_values.Count);
+      Assert.Equal(6.1f, msg2.Float32_values[0]);
+      Assert.Equal(7.1f, msg2.Float32_values[1]);
+      Assert.Equal(8.1f, msg2.Float32_values[2]);
+
+      // float64_values
+      Assert.Equal(3, msg2.Float64_values.Count);
+      Assert.Equal(9.1, msg2.Float64_values[0]);
+      Assert.Equal(10.1, msg2.Float64_values[1]);
+      Assert.Equal(11.1, msg2.Float64_values[2]);
+
+      // int8_values
+      Assert.Equal(3, msg2.Int8_values.Count);
+      Assert.Equal(12, msg2.Int8_values[0]);
+      Assert.Equal(13, msg2.Int8_values[1]);
+      Assert.Equal(14, msg2.Int8_values[2]);
+
+      // uint8_values
+      Assert.Equal(3, msg2.Uint8_values.Count);
+      Assert.Equal(15, msg2.Uint8_values[0]);
+      Assert.Equal(16, msg2.Uint8_values[1]);
+      Assert.Equal(17, msg2.Uint8_values[2]);
+
+      // int16_values
+      Assert.Equal(3, msg2.Int16_values.Count);
+      Assert.Equal(18, msg2.Int16_values[0]);
+      Assert.Equal(19, msg2.Int16_values[1]);
+      Assert.Equal(20, msg2.Int16_values[2]);
+
+      // uint16_values
+      Assert.Equal(3, msg2.Uint16_values.Count);
+      Assert.Equal(21, msg2.Uint16_values[0]);
+      Assert.Equal(22, msg2.Uint16_values[1]);
+      Assert.Equal(23, msg2.Uint16_values[2]);
+
+      // int32_values
+      Assert.Equal(3, msg2.Int32_values.Count);
+      Assert.Equal(24, msg2.Int32_values[0]);
+      Assert.Equal(25, msg2.Int32_values[1]);
+      Assert.Equal(26, msg2.Int32_values[2]);
+      
+      // uint32_values
+      Assert.Equal(3, msg2.Uint32_values.Count);
+      Assert.Equal((uint)27, msg2.Uint32_values[0]);
+      Assert.Equal((uint)28, msg2.Uint32_values[1]);
+      Assert.Equal((uint)29, msg2.Uint32_values[2]);
+
+      // int64_values
+      Assert.Equal(3, msg2.Int64_values.Count);
+      Assert.Equal(30, msg2.Int64_values[0]);
+      Assert.Equal(31, msg2.Int64_values[1]);
+      Assert.Equal(32, msg2.Int64_values[2]);
+      
+      // uint64_values
+      Assert.Equal(3, msg2.Uint64_values.Count);
+      Assert.Equal((ulong)33, msg2.Uint64_values[0]);
+      Assert.Equal((ulong)34, msg2.Uint64_values[1]);
+      Assert.Equal((ulong)35, msg2.Uint64_values[2]);
+
+      // string_values
+      Assert.Equal(3, msg2.String_values.Count);
+      Assert.Equal("one", msg2.String_values[0]);
+      Assert.Equal("two", msg2.String_values[1]);
+      Assert.Equal("three", msg2.String_values[2]);
+      
+      Assert.Equal(3, msg2.Basic_types_values.Count);
+      Assert.True(msg2.Basic_types_values[0].Bool_value);
+      Assert.Equal(36, msg2.Basic_types_values[0].Byte_value);
+      Assert.Equal(37, msg2.Basic_types_values[0].Char_value);
+      Assert.Equal(38.1f, msg2.Basic_types_values[0].Float32_value);
+      Assert.Equal(39.1, msg2.Basic_types_values[0].Float64_value);
+      Assert.Equal(40, msg2.Basic_types_values[0].Int8_value);
+      Assert.Equal(41, msg2.Basic_types_values[0].Uint8_value);
+      Assert.Equal(42, msg2.Basic_types_values[0].Int16_value);
+      Assert.Equal(43, msg2.Basic_types_values[0].Uint16_value);
+      Assert.Equal(44, msg2.Basic_types_values[0].Int32_value);
+      Assert.Equal((uint)45, msg2.Basic_types_values[0].Uint32_value);
+      Assert.Equal(46, msg2.Basic_types_values[0].Int64_value);
+      Assert.Equal((ulong)47, msg2.Basic_types_values[0].Uint64_value);
+
+      Assert.False(msg2.Basic_types_values[1].Bool_value);
+      Assert.Equal(48, msg2.Basic_types_values[1].Byte_value);
+      Assert.Equal(49, msg2.Basic_types_values[1].Char_value);
+      Assert.Equal(50.1f, msg2.Basic_types_values[1].Float32_value);
+      Assert.Equal(51.1, msg2.Basic_types_values[1].Float64_value);
+      Assert.Equal(52, msg2.Basic_types_values[1].Int8_value);
+      Assert.Equal(53, msg2.Basic_types_values[1].Uint8_value);
+      Assert.Equal(54, msg2.Basic_types_values[1].Int16_value);
+      Assert.Equal(55, msg2.Basic_types_values[1].Uint16_value);
+      Assert.Equal(56, msg2.Basic_types_values[1].Int32_value);
+      Assert.Equal((uint)57, msg2.Basic_types_values[1].Uint32_value);
+      Assert.Equal(58, msg2.Basic_types_values[1].Int64_value);
+      Assert.Equal((ulong)59, msg2.Basic_types_values[1].Uint64_value);
+ 
+      Assert.True(msg2.Basic_types_values[2].Bool_value);
+      Assert.Equal(60, msg2.Basic_types_values[2].Byte_value);
+      Assert.Equal(61, msg2.Basic_types_values[2].Char_value);
+      Assert.Equal(62.1f, msg2.Basic_types_values[2].Float32_value);
+      Assert.Equal(63.1, msg2.Basic_types_values[2].Float64_value);
+      Assert.Equal(64, msg2.Basic_types_values[2].Int8_value);
+      Assert.Equal(65, msg2.Basic_types_values[2].Uint8_value);
+      Assert.Equal(66, msg2.Basic_types_values[2].Int16_value);
+      Assert.Equal(67, msg2.Basic_types_values[2].Uint16_value);
+      Assert.Equal(68, msg2.Basic_types_values[2].Int32_value);
+      Assert.Equal((uint)69, msg2.Basic_types_values[2].Uint32_value);
+      Assert.Equal(70, msg2.Basic_types_values[2].Int64_value);
+      Assert.Equal((ulong)71, msg2.Basic_types_values[2].Uint64_value);
+    }
+
+    [Fact]
+    public void TestPublishBoundedSequences()
+    {
+      RCLdotnet.Init();
+      INode node_array_1 = RCLdotnet.CreateNode("test_bounded_sequences_1");
+      INode node_array_2 = RCLdotnet.CreateNode("test_bounded_sequences_2");
+      IPublisher<test_msgs.msg.BoundedSequences> chatter_pub = node_array_1.CreatePublisher<test_msgs.msg.BoundedSequences>("topic_bounded_sequences");
+
+      test_msgs.msg.BoundedSequences msg = new test_msgs.msg.BoundedSequences();
+      test_msgs.msg.BoundedSequences msg2 = new test_msgs.msg.BoundedSequences();
+
+      // bool_values
+      msg.Bool_values.Add(true);
+      msg.Bool_values.Add(false);
+      msg.Bool_values.Add(true);
+
+      // byte_values
+      msg.Byte_values.Add(0);
+      msg.Byte_values.Add(1);
+      msg.Byte_values.Add(2);
+
+      // char_values
+      msg.Char_values.Add(3);
+      msg.Char_values.Add(4);
+      msg.Char_values.Add(5);
+
+      // float32_values
+      msg.Float32_values.Add(6.1f);
+      msg.Float32_values.Add(7.1f);
+      msg.Float32_values.Add(8.1f);
+
+      // float64_values
+      msg.Float64_values.Add(9.1);
+      msg.Float64_values.Add(10.1);
+      msg.Float64_values.Add(11.1);
+
+      // int8_values
+      msg.Int8_values.Add(12);
+      msg.Int8_values.Add(13);
+      msg.Int8_values.Add(14);
+
+      // uint8_values
+      msg.Uint8_values.Add(15);
+      msg.Uint8_values.Add(16);
+      msg.Uint8_values.Add(17);
+
+      // int16_values
+      msg.Int16_values.Add(18);
+      msg.Int16_values.Add(19);
+      msg.Int16_values.Add(20);
+
+      // uint16_values
+      msg.Uint16_values.Add(21);
+      msg.Uint16_values.Add(22);
+      msg.Uint16_values.Add(23);
+
+      // int32_values
+      msg.Int32_values.Add(24);
+      msg.Int32_values.Add(25);
+      msg.Int32_values.Add(26);
+
+      // uint32_values
+      msg.Uint32_values.Add(27);
+      msg.Uint32_values.Add(28);
+      msg.Uint32_values.Add(29);
+
+      // int64_values
+      msg.Int64_values.Add(30);
+      msg.Int64_values.Add(31);
+      msg.Int64_values.Add(32);
+
+      // uint64_values
+      msg.Uint64_values.Add(33);
+      msg.Uint64_values.Add(34);
+      msg.Uint64_values.Add(35);
+
+      // string_values
+      msg.String_values.Add("one");
+      msg.String_values.Add("two");
+      msg.String_values.Add("three");
+
+      test_msgs.msg.BasicTypes basic_type_1 = new test_msgs.msg.BasicTypes();
+      basic_type_1.Bool_value = true;
+      basic_type_1.Byte_value = 36;
+      basic_type_1.Char_value = 37;
+      basic_type_1.Float32_value = 38.1f;
+      basic_type_1.Float64_value = 39.1;
+      basic_type_1.Int8_value = 40;
+      basic_type_1.Uint8_value = 41;
+      basic_type_1.Int16_value = 42;
+      basic_type_1.Uint16_value = 43;
+      basic_type_1.Int32_value = 44;
+      basic_type_1.Uint32_value = 45;
+      basic_type_1.Int64_value = 46;
+      basic_type_1.Uint64_value = 47;
+
+      test_msgs.msg.BasicTypes basic_type_2 = new test_msgs.msg.BasicTypes();
+      basic_type_2.Bool_value = false;
+      basic_type_2.Byte_value = 48;
+      basic_type_2.Char_value = 49;
+      basic_type_2.Float32_value = 50.1f;
+      basic_type_2.Float64_value = 51.1;
+      basic_type_2.Int8_value = 52;
+      basic_type_2.Uint8_value = 53;
+      basic_type_2.Int16_value = 54;
+      basic_type_2.Uint16_value = 55;
+      basic_type_2.Int32_value = 56;
+      basic_type_2.Uint32_value = 57;
+      basic_type_2.Int64_value = 58;
+      basic_type_2.Uint64_value = 59;
+
+      test_msgs.msg.BasicTypes basic_type_3 = new test_msgs.msg.BasicTypes();
+      basic_type_3.Bool_value = true;
+      basic_type_3.Byte_value = 60;
+      basic_type_3.Char_value = 61;
+      basic_type_3.Float32_value = 62.1f;
+      basic_type_3.Float64_value = 63.1;
+      basic_type_3.Int8_value = 64;
+      basic_type_3.Uint8_value = 65;
+      basic_type_3.Int16_value = 66;
+      basic_type_3.Uint16_value = 67;
+      basic_type_3.Int32_value = 68;
+      basic_type_3.Uint32_value = 69;
+      basic_type_3.Int64_value = 70;
+      basic_type_3.Uint64_value = 71;
+
+      msg.Basic_types_values.Add(basic_type_1);
+      msg.Basic_types_values.Add(basic_type_2);
+      msg.Basic_types_values.Add(basic_type_3);
+
+      bool received=false;
+      ISubscription<test_msgs.msg.BoundedSequences> chatter_sub = node_array_2.CreateSubscription<test_msgs.msg.BoundedSequences>(
+        "topic_bounded_sequences", rcv_msg =>
+        {
+          received=true;
+          msg2 = rcv_msg;
+        }
+      );
+
+      while(!received)
+      {
+        chatter_pub.Publish(msg);
+
+        RCLdotnet.SpinOnce(node_array_1, 500);
+        RCLdotnet.SpinOnce(node_array_2, 500);
+      }
+
+      // bool_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Bool_values_MaxCount);
+      Assert.Equal(3, msg2.Bool_values.Count);
+      Assert.True(msg2.Bool_values[0]);
+      Assert.False(msg2.Bool_values[1]);
+      Assert.True(msg2.Bool_values[2]);
+
+      // byte_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Byte_values_MaxCount);
+      Assert.Equal(3, msg2.Byte_values.Count);
+      Assert.Equal(0, msg2.Byte_values[0]);
+      Assert.Equal(1, msg2.Byte_values[1]);
+      Assert.Equal(2, msg2.Byte_values[2]);
+
+      // char_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Char_values_MaxCount);
+      Assert.Equal(3, msg2.Char_values.Count);
+      Assert.Equal(3, msg2.Char_values[0]);
+      Assert.Equal(4, msg2.Char_values[1]);
+      Assert.Equal(5, msg2.Char_values[2]);
+
+      // float32_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Float32_values_MaxCount);
+      Assert.Equal(3, msg2.Float32_values.Count);
+      Assert.Equal(6.1f, msg2.Float32_values[0]);
+      Assert.Equal(7.1f, msg2.Float32_values[1]);
+      Assert.Equal(8.1f, msg2.Float32_values[2]);
+
+      // float64_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Float64_values_MaxCount);
+      Assert.Equal(3, msg2.Float64_values.Count);
+      Assert.Equal(9.1, msg2.Float64_values[0]);
+      Assert.Equal(10.1, msg2.Float64_values[1]);
+      Assert.Equal(11.1, msg2.Float64_values[2]);
+
+      // int8_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Int8_values_MaxCount);
+      Assert.Equal(3, msg2.Int8_values.Count);
+      Assert.Equal(12, msg2.Int8_values[0]);
+      Assert.Equal(13, msg2.Int8_values[1]);
+      Assert.Equal(14, msg2.Int8_values[2]);
+
+      // uint8_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Uint8_values_MaxCount);
+      Assert.Equal(3, msg2.Uint8_values.Count);
+      Assert.Equal(15, msg2.Uint8_values[0]);
+      Assert.Equal(16, msg2.Uint8_values[1]);
+      Assert.Equal(17, msg2.Uint8_values[2]);
+
+      // int16_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Int16_values_MaxCount);
+      Assert.Equal(3, msg2.Int16_values.Count);
+      Assert.Equal(18, msg2.Int16_values[0]);
+      Assert.Equal(19, msg2.Int16_values[1]);
+      Assert.Equal(20, msg2.Int16_values[2]);
+
+      // uint16_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Uint16_values_MaxCount);
+      Assert.Equal(3, msg2.Uint16_values.Count);
+      Assert.Equal(21, msg2.Uint16_values[0]);
+      Assert.Equal(22, msg2.Uint16_values[1]);
+      Assert.Equal(23, msg2.Uint16_values[2]);
+
+      // int32_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Int32_values_MaxCount);
+      Assert.Equal(3, msg2.Int32_values.Count);
+      Assert.Equal(24, msg2.Int32_values[0]);
+      Assert.Equal(25, msg2.Int32_values[1]);
+      Assert.Equal(26, msg2.Int32_values[2]);
+      
+      // uint32_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Uint32_values_MaxCount);
+      Assert.Equal(3, msg2.Uint32_values.Count);
+      Assert.Equal((uint)27, msg2.Uint32_values[0]);
+      Assert.Equal((uint)28, msg2.Uint32_values[1]);
+      Assert.Equal((uint)29, msg2.Uint32_values[2]);
+
+      // int64_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Int64_values_MaxCount);
+      Assert.Equal(3, msg2.Int64_values.Count);
+      Assert.Equal(30, msg2.Int64_values[0]);
+      Assert.Equal(31, msg2.Int64_values[1]);
+      Assert.Equal(32, msg2.Int64_values[2]);
+      
+      // uint64_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Uint64_values_MaxCount);
+      Assert.Equal(3, msg2.Uint64_values.Count);
+      Assert.Equal((ulong)33, msg2.Uint64_values[0]);
+      Assert.Equal((ulong)34, msg2.Uint64_values[1]);
+      Assert.Equal((ulong)35, msg2.Uint64_values[2]);
+
+      // string_values
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.String_values_MaxCount);
+      Assert.Equal(3, msg2.String_values.Count);
+      Assert.Equal("one", msg2.String_values[0]);
+      Assert.Equal("two", msg2.String_values[1]);
+      Assert.Equal("three", msg2.String_values[2]);
+      
+      Assert.Equal(3, test_msgs.msg.BoundedSequences.Basic_types_values_MaxCount);
+      Assert.Equal(3, msg2.Basic_types_values.Count);
+      Assert.True(msg2.Basic_types_values[0].Bool_value);
+      Assert.Equal(36, msg2.Basic_types_values[0].Byte_value);
+      Assert.Equal(37, msg2.Basic_types_values[0].Char_value);
+      Assert.Equal(38.1f, msg2.Basic_types_values[0].Float32_value);
+      Assert.Equal(39.1, msg2.Basic_types_values[0].Float64_value);
+      Assert.Equal(40, msg2.Basic_types_values[0].Int8_value);
+      Assert.Equal(41, msg2.Basic_types_values[0].Uint8_value);
+      Assert.Equal(42, msg2.Basic_types_values[0].Int16_value);
+      Assert.Equal(43, msg2.Basic_types_values[0].Uint16_value);
+      Assert.Equal(44, msg2.Basic_types_values[0].Int32_value);
+      Assert.Equal((uint)45, msg2.Basic_types_values[0].Uint32_value);
+      Assert.Equal(46, msg2.Basic_types_values[0].Int64_value);
+      Assert.Equal((ulong)47, msg2.Basic_types_values[0].Uint64_value);
+
+      Assert.False(msg2.Basic_types_values[1].Bool_value);
+      Assert.Equal(48, msg2.Basic_types_values[1].Byte_value);
+      Assert.Equal(49, msg2.Basic_types_values[1].Char_value);
+      Assert.Equal(50.1f, msg2.Basic_types_values[1].Float32_value);
+      Assert.Equal(51.1, msg2.Basic_types_values[1].Float64_value);
+      Assert.Equal(52, msg2.Basic_types_values[1].Int8_value);
+      Assert.Equal(53, msg2.Basic_types_values[1].Uint8_value);
+      Assert.Equal(54, msg2.Basic_types_values[1].Int16_value);
+      Assert.Equal(55, msg2.Basic_types_values[1].Uint16_value);
+      Assert.Equal(56, msg2.Basic_types_values[1].Int32_value);
+      Assert.Equal((uint)57, msg2.Basic_types_values[1].Uint32_value);
+      Assert.Equal(58, msg2.Basic_types_values[1].Int64_value);
+      Assert.Equal((ulong)59, msg2.Basic_types_values[1].Uint64_value);
+ 
+      Assert.True(msg2.Basic_types_values[2].Bool_value);
+      Assert.Equal(60, msg2.Basic_types_values[2].Byte_value);
+      Assert.Equal(61, msg2.Basic_types_values[2].Char_value);
+      Assert.Equal(62.1f, msg2.Basic_types_values[2].Float32_value);
+      Assert.Equal(63.1, msg2.Basic_types_values[2].Float64_value);
+      Assert.Equal(64, msg2.Basic_types_values[2].Int8_value);
+      Assert.Equal(65, msg2.Basic_types_values[2].Uint8_value);
+      Assert.Equal(66, msg2.Basic_types_values[2].Int16_value);
+      Assert.Equal(67, msg2.Basic_types_values[2].Uint16_value);
+      Assert.Equal(68, msg2.Basic_types_values[2].Int32_value);
+      Assert.Equal((uint)69, msg2.Basic_types_values[2].Uint32_value);
+      Assert.Equal(70, msg2.Basic_types_values[2].Int64_value);
+      Assert.Equal((ulong)71, msg2.Basic_types_values[2].Uint64_value);
+    }
   }
 }

--- a/rcldotnet/test/test_messages.cs
+++ b/rcldotnet/test/test_messages.cs
@@ -159,9 +159,9 @@ namespace RCLdotnetTests
       msg.Uint64_values.Add(35);
 
       // string_values
-      // msg.String_values.Add("one");
-      // msg.String_values.Add("two");
-      // msg.String_values.Add("three");
+      msg.String_values.Add("one");
+      msg.String_values.Add("two");
+      msg.String_values.Add("three");
 
       test_msgs.msg.BasicTypes basic_type_1 = new test_msgs.msg.BasicTypes();
       basic_type_1.Bool_value = true;
@@ -295,10 +295,10 @@ namespace RCLdotnetTests
       Assert.Equal((ulong)35, msg2.Uint64_values[2]);
 
       // string_values
-      // Not supported yet
-      // Assert.Equal("one", msg2.String_values[0]);
-      // Assert.Equal("two", msg2.String_values[1]);
-      // Assert.Equal("three", msg2.String_values[2]);
+      Assert.Equal("one", msg2.String_values[0]);
+      Assert.Equal("two", msg2.String_values[1]);
+      Assert.Equal("three", msg2.String_values[2]);
+      
       Assert.Equal(3, msg2.Basic_types_values.Count);
       Assert.True(msg2.Basic_types_values[0].Bool_value);
       Assert.Equal(36, msg2.Basic_types_values[0].Byte_value);

--- a/rcldotnet/test/test_messages.cs
+++ b/rcldotnet/test/test_messages.cs
@@ -94,75 +94,76 @@ namespace RCLdotnetTests
       test_msgs.msg.Arrays msg2 = new test_msgs.msg.Arrays ();
 
       // bool_values
-      msg.Bool_values.Add(true);
-      msg.Bool_values.Add(false);
-      msg.Bool_values.Add(true);
+      msg.Bool_values[0] = true;
+      msg.Bool_values[1] = false;
+      msg.Bool_values[2] = true;
 
       // byte_values
-      msg.Byte_values.Add(0);
-      msg.Byte_values.Add(1);
-      msg.Byte_values.Add(2);
+      msg.Byte_values[0] = 0;
+      msg.Byte_values[1] = 1;
+      msg.Byte_values[2] = 2;
 
       // char_values
-      msg.Char_values.Add(3);
-      msg.Char_values.Add(4);
-      msg.Char_values.Add(5);
+      msg.Char_values[0] = 3;
+      msg.Char_values[1] = 4;
+      msg.Char_values[2] = 5;
 
       // float32_values
-      msg.Float32_values.Add(6.1f);
-      msg.Float32_values.Add(7.1f);
-      msg.Float32_values.Add(8.1f);
+      msg.Float32_values[0] = 6.1f;
+      msg.Float32_values[1] = 7.1f;
+      msg.Float32_values[2] = 8.1f;
 
       // float64_values
-      msg.Float64_values.Add(9.1);
-      msg.Float64_values.Add(10.1);
-      msg.Float64_values.Add(11.1);
+      msg.Float64_values[0] = 9.1;
+      msg.Float64_values[1] = 10.1;
+      msg.Float64_values[2] = 11.1;
 
       // int8_values
-      msg.Int8_values.Add(12);
-      msg.Int8_values.Add(13);
-      msg.Int8_values.Add(14);
+      msg.Int8_values[0] = 12;
+      msg.Int8_values[1] = 13;
+      msg.Int8_values[2] = 14;
 
       // uint8_values
-      msg.Uint8_values.Add(15);
-      msg.Uint8_values.Add(16);
-      msg.Uint8_values.Add(17);
+      msg.Uint8_values[0] = 15;
+      msg.Uint8_values[1] = 16;
+      msg.Uint8_values[2] = 17;
 
       // int16_values
-      msg.Int16_values.Add(18);
-      msg.Int16_values.Add(19);
-      msg.Int16_values.Add(20);
+      msg.Int16_values[0] = 18;
+      msg.Int16_values[1] = 19;
+      msg.Int16_values[2] = 20;
 
       // uint16_values
-      msg.Uint16_values.Add(21);
-      msg.Uint16_values.Add(22);
-      msg.Uint16_values.Add(23);
+      msg.Uint16_values[0] = 21;
+      msg.Uint16_values[1] = 22;
+      msg.Uint16_values[2] = 23;
 
       // int32_values
-      msg.Int32_values.Add(24);
-      msg.Int32_values.Add(25);
-      msg.Int32_values.Add(26);
+      msg.Int32_values[0] = 24;
+      msg.Int32_values[1] = 25;
+      msg.Int32_values[2] = 26;
 
       // uint32_values
-      msg.Uint32_values.Add(27);
-      msg.Uint32_values.Add(28);
-      msg.Uint32_values.Add(29);
+      msg.Uint32_values[0] = 27;
+      msg.Uint32_values[1] = 28;
+      msg.Uint32_values[2] = 29;
 
       // int64_values
-      msg.Int64_values.Add(30);
-      msg.Int64_values.Add(31);
-      msg.Int64_values.Add(32);
+      msg.Int64_values[0] = 30;
+      msg.Int64_values[1] = 31;
+      msg.Int64_values[2] = 32;
 
       // uint64_values
-      msg.Uint64_values.Add(33);
-      msg.Uint64_values.Add(34);
-      msg.Uint64_values.Add(35);
+      msg.Uint64_values[0] = 33;
+      msg.Uint64_values[1] = 34;
+      msg.Uint64_values[2] = 35;
 
       // string_values
-      msg.String_values.Add("one");
-      msg.String_values.Add("two");
-      msg.String_values.Add("three");
+      msg.String_values[0] = "one";
+      msg.String_values[1] = "two";
+      msg.String_values[2] = "three";
 
+      // basic_types_values
       test_msgs.msg.BasicTypes basic_type_1 = new test_msgs.msg.BasicTypes();
       basic_type_1.Bool_value = true;
       basic_type_1.Byte_value = 36;
@@ -208,9 +209,9 @@ namespace RCLdotnetTests
       basic_type_3.Int64_value = 70;
       basic_type_3.Uint64_value = 71;
 
-      msg.Basic_types_values.Add(basic_type_1);
-      msg.Basic_types_values.Add(basic_type_2);
-      msg.Basic_types_values.Add(basic_type_3);
+      msg.Basic_types_values[0] = basic_type_1;
+      msg.Basic_types_values[1] = basic_type_2;
+      msg.Basic_types_values[2] = basic_type_3;
 
       bool received=false;
       ISubscription<test_msgs.msg.Arrays> chatter_sub = node_array_2.CreateSubscription<test_msgs.msg.Arrays> (
@@ -230,105 +231,107 @@ namespace RCLdotnetTests
       }
 
       // bool_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Bool_values_Count);
-      Assert.Equal(3, msg2.Bool_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Bool_values_Length);
+      Assert.Equal(3, msg2.Bool_values.Length);
       Assert.True(msg2.Bool_values[0]);
       Assert.False(msg2.Bool_values[1]);
       Assert.True(msg2.Bool_values[2]);
 
       // byte_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Byte_values_Count);
-      Assert.Equal(3, msg2.Byte_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Byte_values_Length);
+      Assert.Equal(3, msg2.Byte_values.Length);
       Assert.Equal(0, msg2.Byte_values[0]);
       Assert.Equal(1, msg2.Byte_values[1]);
       Assert.Equal(2, msg2.Byte_values[2]);
 
       // char_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Char_values_Count);
-      Assert.Equal(3, msg2.Char_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Char_values_Length);
+      Assert.Equal(3, msg2.Char_values.Length);
       Assert.Equal(3, msg2.Char_values[0]);
       Assert.Equal(4, msg2.Char_values[1]);
       Assert.Equal(5, msg2.Char_values[2]);
 
       // float32_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Float32_values_Count);
-      Assert.Equal(3, msg2.Float32_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Float32_values_Length);
+      Assert.Equal(3, msg2.Float32_values.Length);
       Assert.Equal(6.1f, msg2.Float32_values[0]);
       Assert.Equal(7.1f, msg2.Float32_values[1]);
       Assert.Equal(8.1f, msg2.Float32_values[2]);
 
       // float64_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Float64_values_Count);
-      Assert.Equal(3, msg2.Float64_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Float64_values_Length);
+      Assert.Equal(3, msg2.Float64_values.Length);
       Assert.Equal(9.1, msg2.Float64_values[0]);
       Assert.Equal(10.1, msg2.Float64_values[1]);
       Assert.Equal(11.1, msg2.Float64_values[2]);
 
       // int8_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Int8_values_Count);
-      Assert.Equal(3, msg2.Int8_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Int8_values_Length);
+      Assert.Equal(3, msg2.Int8_values.Length);
       Assert.Equal(12, msg2.Int8_values[0]);
       Assert.Equal(13, msg2.Int8_values[1]);
       Assert.Equal(14, msg2.Int8_values[2]);
 
       // uint8_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Uint8_values_Count);
-      Assert.Equal(3, msg2.Uint8_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint8_values_Length);
+      Assert.Equal(3, msg2.Uint8_values.Length);
       Assert.Equal(15, msg2.Uint8_values[0]);
       Assert.Equal(16, msg2.Uint8_values[1]);
       Assert.Equal(17, msg2.Uint8_values[2]);
 
       // int16_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Int16_values_Count);
-      Assert.Equal(3, msg2.Int16_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Int16_values_Length);
+      Assert.Equal(3, msg2.Int16_values.Length);
       Assert.Equal(18, msg2.Int16_values[0]);
       Assert.Equal(19, msg2.Int16_values[1]);
       Assert.Equal(20, msg2.Int16_values[2]);
 
       // uint16_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Uint16_values_Count);
-      Assert.Equal(3, msg2.Uint16_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint16_values_Length);
+      Assert.Equal(3, msg2.Uint16_values.Length);
       Assert.Equal(21, msg2.Uint16_values[0]);
       Assert.Equal(22, msg2.Uint16_values[1]);
       Assert.Equal(23, msg2.Uint16_values[2]);
 
       // int32_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Int32_values_Count);
-      Assert.Equal(3, msg2.Int32_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Int32_values_Length);
+      Assert.Equal(3, msg2.Int32_values.Length);
       Assert.Equal(24, msg2.Int32_values[0]);
       Assert.Equal(25, msg2.Int32_values[1]);
       Assert.Equal(26, msg2.Int32_values[2]);
       
       // uint32_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Uint32_values_Count);
-      Assert.Equal(3, msg2.Uint32_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint32_values_Length);
+      Assert.Equal(3, msg2.Uint32_values.Length);
       Assert.Equal((uint)27, msg2.Uint32_values[0]);
       Assert.Equal((uint)28, msg2.Uint32_values[1]);
       Assert.Equal((uint)29, msg2.Uint32_values[2]);
 
       // int64_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Int64_values_Count);
-      Assert.Equal(3, msg2.Int64_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Int64_values_Length);
+      Assert.Equal(3, msg2.Int64_values.Length);
       Assert.Equal(30, msg2.Int64_values[0]);
       Assert.Equal(31, msg2.Int64_values[1]);
       Assert.Equal(32, msg2.Int64_values[2]);
       
       // uint64_values
-      Assert.Equal(3, test_msgs.msg.Arrays.Uint64_values_Count);
-      Assert.Equal(3, msg2.Uint64_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.Uint64_values_Length);
+      Assert.Equal(3, msg2.Uint64_values.Length);
       Assert.Equal((ulong)33, msg2.Uint64_values[0]);
       Assert.Equal((ulong)34, msg2.Uint64_values[1]);
       Assert.Equal((ulong)35, msg2.Uint64_values[2]);
 
       // string_values
-      Assert.Equal(3, test_msgs.msg.Arrays.String_values_Count);
-      Assert.Equal(3, msg2.String_values.Count);
+      Assert.Equal(3, test_msgs.msg.Arrays.String_values_Length);
+      Assert.Equal(3, msg2.String_values.Length);
       Assert.Equal("one", msg2.String_values[0]);
       Assert.Equal("two", msg2.String_values[1]);
       Assert.Equal("three", msg2.String_values[2]);
-      
-      Assert.Equal(3, test_msgs.msg.Arrays.Basic_types_values_Count);
-      Assert.Equal(3, msg2.Basic_types_values.Count);
+
+      // basic_types_values
+      Assert.Equal(3, test_msgs.msg.Arrays.Basic_types_values_Length);
+      Assert.Equal(3, msg2.Basic_types_values.Length);
+
       Assert.True(msg2.Basic_types_values[0].Bool_value);
       Assert.Equal(36, msg2.Basic_types_values[0].Byte_value);
       Assert.Equal(37, msg2.Basic_types_values[0].Char_value);

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -70,13 +70,14 @@ void @(msg_typename)__write_field_@(member.name)(void *message_handle, @(msg_typ
 @[        elif isinstance(member.type.value_type, AbstractString)]@
 void @(msg_typename)__write_field_@(member.name)(void *message_handle, @(msg_type_to_c(member.type.value_type)) value)
 {
-  
+  rosidl_runtime_c__String * ros_message = (rosidl_runtime_c__String *)message_handle;
+  rosidl_runtime_c__String__assign(ros_message, value); 
 }
 
 @(msg_type_to_c(member.type.value_type)) @(msg_typename)__read_field_@(member.name)(void *message_handle)
 {
-  @(msg_typename) * ros_message = (@(msg_typename)*)message_handle;
-  return ros_message->@(member.name)->data;
+  rosidl_runtime_c__String * ros_message = (rosidl_runtime_c__String *)message_handle;
+  return ros_message->data;
 }
 @[        end if]@
 

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -50,7 +50,7 @@ const void * @(msg_typename)__get_typesupport() {
 
 @[for member in message.structure.members]@
 @[    if isinstance(member.type, Array) or isinstance(member.type, AbstractSequence)]@
-void * @(msg_typename)__get_field_@(member.name)_message(void *message_handle, int index) {
+void * @(msg_typename)__get_field_@(member.name)_message(void *message_handle, int32_t index) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
 @[        if isinstance(member.type, Array)]@
   return &(ros_message->@(member.name)[index]);
@@ -60,12 +60,12 @@ void * @(msg_typename)__get_field_@(member.name)_message(void *message_handle, i
 }
 
 @[        if isinstance(member.type, AbstractSequence)]@
-int @(msg_typename)__getsize_field_@(member.name)_message(void *message_handle) {
+int32_t @(msg_typename)__getsize_field_@(member.name)_message(void *message_handle) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
   return ros_message->@(member.name).size;
 }
 
-bool @(msg_typename)__init_sequence_field_@(member.name)_message(void *message_handle, int size) {
+bool @(msg_typename)__init_sequence_field_@(member.name)_message(void *message_handle, int32_t size) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
 
   rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -1,4 +1,6 @@
 @{
+from rosidl_generator_c import idl_type_to_c
+
 from rosidl_generator_dotnet import msg_type_to_c
 
 from rosidl_parser.definition import AbstractNestedType
@@ -21,6 +23,8 @@ header_filename = "{0}/rcldotnet_{1}.h".format('/'.join(message.structure.namesp
 #include <stdio.h>
 #include <assert.h>
 #include <stdint.h>
+
+#include <rcutils/allocator.h>
 
 #include <@('/'.join(message.structure.namespaced_type.namespaces))/@(convert_camel_case_to_lower_case_underscore(type_name)).h>
 #include "rosidl_runtime_c/message_type_support_struct.h"
@@ -45,11 +49,49 @@ const void * @(msg_typename)__get_typesupport() {
 }
 
 @[for member in message.structure.members]@
-@[    if isinstance(member.type, Array)]@
+@[    if isinstance(member.type, Array) or isinstance(member.type, AbstractSequence)]@
 void * @(msg_typename)__get_field_@(member.name)_message(void *message_handle, int index) {
   @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
+@[        if isinstance(member.type, Array)]@
   return &(ros_message->@(member.name)[index]);
+@[        elif isinstance(member.type, AbstractSequence)]@
+  return &(ros_message->@(member.name).data[index]);
+@[        end if]@
 }
+
+@[        if isinstance(member.type, AbstractSequence)]@
+int @(msg_typename)__getsize_field_@(member.name)_message(void *message_handle) {
+  @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
+  return ros_message->@(member.name).size;
+}
+
+bool @(msg_typename)__init_sequence_field_@(member.name)_message(void *message_handle, int size) {
+  @(msg_typename) * ros_message = (@(msg_typename) *)message_handle;
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (ros_message->@(member.name).data) {
+    allocator.deallocate(ros_message->@(member.name).data, allocator.state);
+    ros_message->@(member.name).data = NULL;
+    ros_message->@(member.name).size = 0;
+    ros_message->@(member.name).capacity = 0;
+  }
+
+  @(idl_type_to_c(member.type.value_type)) * data = NULL;
+  if (size) {
+    data = (@(idl_type_to_c(member.type.value_type)) *)allocator.zero_allocate(
+      size, sizeof(@(idl_type_to_c(member.type.value_type))), allocator.state);
+    if (!data) {
+      return false;
+    }
+  }
+  
+  ros_message->@(member.name).data = data;
+  ros_message->@(member.name).size = size;
+  ros_message->@(member.name).capacity = size;
+  return true;
+}
+@[        end if]@
 
 @[        if isinstance(member.type.value_type, BasicType)]@
 void @(msg_typename)__write_field_@(member.name)(void *message_handle, @(msg_type_to_c(member.type.value_type)) value)
@@ -77,9 +119,6 @@ void @(msg_typename)__write_field_@(member.name)(void *message_handle, @(msg_typ
 }
 @[        end if]@
 
-////////////////////////////////////////////////////////
-@[    elif isinstance(member.type, AbstractSequence)]@
-// TODO: Sequence types are not supported
 @[    elif isinstance(member.type, AbstractWString)]@
 // TODO: Unicode types are not supported
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -52,11 +52,7 @@ void * @(msg_typename)__get_field_@(member.name)_message(void *message_handle, i
 }
 
 int @(msg_typename)__getsize_array_field_@(member.name)_message() {
-@[        if isinstance(member.type, Array)]@
   return @(member.type.size);
-@[        else]@
-  return 0;
-@[        end if]@
 }
 
 @[        if isinstance(member.type.value_type, BasicType)]@

--- a/rosidl_generator_dotnet/resource/msg.c.em
+++ b/rosidl_generator_dotnet/resource/msg.c.em
@@ -51,10 +51,6 @@ void * @(msg_typename)__get_field_@(member.name)_message(void *message_handle, i
   return &(ros_message->@(member.name)[index]);
 }
 
-int @(msg_typename)__getsize_array_field_@(member.name)_message() {
-  return @(member.type.size);
-}
-
 @[        if isinstance(member.type.value_type, BasicType)]@
 void @(msg_typename)__write_field_@(member.name)(void *message_handle, @(msg_type_to_c(member.type.value_type)) value)
 {

--- a/rosidl_generator_dotnet/resource/msg.cs.em
+++ b/rosidl_generator_dotnet/resource/msg.cs.em
@@ -212,16 +212,16 @@ public class @(type_name) : IMessage {
           @(get_field_name(type_name, member.name)).Clear();
           for (int i=0; i<size; i++)
           {
-          @[        if isinstance(member.type.value_type, BasicType)]@
+@[        if isinstance(member.type.value_type, BasicType)]
               @(get_field_name(type_name, member.name)).Add(native_read_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, i)));
-          @[        elif isinstance(member.type.value_type, AbstractString)]@
+@[        elif isinstance(member.type.value_type, AbstractString)]
               // TODO: String types are not supported  
           @[        elif isinstance(member.type.value_type, AbstractWString)]
               // TODO: Unicode types are not supported  
           @[        else]
               @(get_field_name(type_name, member.name)).Add(new @(get_dotnet_type(member.type.value_type))());
               @(get_field_name(type_name, member.name))[@(get_field_name(type_name, member.name)).Count-1]._READ_HANDLE(native_get_field_@(member.name)_message(messageHandle, i));
-          @[        end if]@
+@[        end if]
         }
       }
 

--- a/rosidl_generator_dotnet/resource/msg.cs.em
+++ b/rosidl_generator_dotnet/resource/msg.cs.em
@@ -292,21 +292,34 @@ public class @(type_name) : IMessage {
 @[for member in message.structure.members]@
 @[    if isinstance(member.type, Array) or isinstance(member.type, AbstractSequence)]@
         {
-            int count__local_variable = 0;
-@[        if isinstance(member.type, AbstractSequence)]@
-            if (!native_init_seqence_field_@(member.name)_message(messageHandle, @(get_field_name(type_name, member.name)).Count))
+@[        if isinstance(member.type, Array)]@
+            var count__local_variable = @(get_field_name(type_name, member.name)).Length;
+            if (count__local_variable != @(member.type.size))
+            {
+                throw new Exception("Invalid size of array '@(get_field_name(type_name, member.name))'.");
+            }
+@[        elif isinstance(member.type, AbstractSequence)]@
+            var count__local_variable = @(get_field_name(type_name, member.name)).Count;
+@[            if member.type.has_maximum_size()]@
+            if (count__local_variable > @(member.type.maximum_size))
+            {
+                throw new Exception("Invalid size of bounded sequence '@(get_field_name(type_name, member.name))'.");
+            }
+@[            end if]@
+            if (!native_init_seqence_field_@(member.name)_message(messageHandle, count__local_variable))
             {
                 throw new Exception("The method 'native_init_seqence_field_@(member.name)_message()' failed.");
             }
 @[        end if]@
-            foreach(@(get_dotnet_type(member.type.value_type)) value in @(get_field_name(type_name, member.name)))
+            for (var i__local_variable = 0; i__local_variable < count__local_variable; i__local_variable++)
             {
+                var value__local_variable = @(get_field_name(type_name, member.name))[i__local_variable];
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
-                native_write_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, count__local_variable++), value);
+                native_write_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, i__local_variable), value__local_variable);
 @[        elif isinstance(member.type.value_type, AbstractWString)]
 // TODO: Unicode types are not supported  
 @[        else]@
-                value._WRITE_HANDLE(native_get_field_@(member.name)_message(messageHandle, count__local_variable++));
+                value__local_variable._WRITE_HANDLE(native_get_field_@(member.name)_message(messageHandle, i__local_variable));
 @[        end if]@
             }
         }

--- a/rosidl_generator_dotnet/resource/msg.cs.em
+++ b/rosidl_generator_dotnet/resource/msg.cs.em
@@ -215,14 +215,15 @@ public class @(type_name) : IMessage {
 @[        if isinstance(member.type.value_type, BasicType)]
               @(get_field_name(type_name, member.name)).Add(native_read_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, i)));
 @[        elif isinstance(member.type.value_type, AbstractString)]
-              // TODO: String types are not supported  
+              IntPtr pStr_@(get_field_name(type_name, member.name)) = native_read_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, i));
+              @(get_field_name(type_name, member.name)).Add(Marshal.PtrToStringAnsi(pStr_@(get_field_name(type_name, member.name))));
           @[        elif isinstance(member.type.value_type, AbstractWString)]
               // TODO: Unicode types are not supported  
           @[        else]
               @(get_field_name(type_name, member.name)).Add(new @(get_dotnet_type(member.type.value_type))());
               @(get_field_name(type_name, member.name))[@(get_field_name(type_name, member.name)).Count-1]._READ_HANDLE(native_get_field_@(member.name)_message(messageHandle, i));
 @[        end if]
-        }
+          }
       }
 
 @[    elif isinstance(member.type, AbstractSequence)]@
@@ -251,8 +252,6 @@ public class @(type_name) : IMessage {
             {
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
                 native_write_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, count++), value);
-@[        elif isinstance(member.type.value_type, AbstractString)]
-// TODO: String types are not supported  
 @[        elif isinstance(member.type.value_type, AbstractWString)]
 // TODO: Unicode types are not supported  
 @[        else]@

--- a/rosidl_generator_dotnet/resource/msg.cs.em
+++ b/rosidl_generator_dotnet/resource/msg.cs.em
@@ -31,6 +31,12 @@ namespace @(ns)
 public class @(type_name) : IMessage {
     private static readonly DllLoadUtils dllLoadUtils;
 
+@[for member in message.structure.members]@
+@[    if isinstance(member.type, Array)]@
+    public const int @(get_field_name(type_name, member.name))_Count = @(member.type.size);
+@[    end if]@
+@[end for]@
+
     public @(type_name)()
     {
 @[for member in message.structure.members]@
@@ -76,7 +82,6 @@ public class @(type_name) : IMessage {
 @[for member in message.structure.members]@
 @[    if isinstance(member.type, Array)]@
         IntPtr native_get_field_@(member.name)_message_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__get_field_@(member.name)_message");
-        IntPtr native_getsize_array_field_@(member.name)_message_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__getsize_array_field_@(member.name)_message");
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
         IntPtr native_write_field_@(member.name)_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__write_field_@(member.name)");
         IntPtr native_read_field_@(member.name)_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(msg_typename)__read_field_@(member.name)");
@@ -84,8 +89,6 @@ public class @(type_name) : IMessage {
 
         @(type_name).native_get_field_@(member.name)_message = (NativeGetField@(get_field_name(type_name, member.name))Type)Marshal.GetDelegateForFunctionPointer(
             native_get_field_@(member.name)_message_ptr, typeof(NativeGetField@(get_field_name(type_name, member.name))Type));
-        @(type_name).native_getsize_array_field_@(member.name)_message = (NativeGetSizeArrayField@(get_field_name(type_name, member.name))Type)Marshal.GetDelegateForFunctionPointer(
-            native_getsize_array_field_@(member.name)_message_ptr, typeof(NativeGetSizeArrayField@(get_field_name(type_name, member.name))Type));
 
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
         @(type_name).native_write_field_@(member.name) = (NativeWriteField@(get_field_name(type_name, member.name))Type)Marshal.GetDelegateForFunctionPointer(
@@ -139,7 +142,6 @@ public class @(type_name) : IMessage {
 @[for member in message.structure.members]@
 @[    if isinstance(member.type, Array)]@
     private static NativeGetField@(get_field_name(type_name, member.name))Type native_get_field_@(member.name)_message = null;
-    private static NativeGetSizeArrayField@(get_field_name(type_name, member.name))Type native_getsize_array_field_@(member.name)_message = null;
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
     private static NativeWriteField@(get_field_name(type_name, member.name))Type native_write_field_@(member.name) = null;
     private static NativeReadField@(get_field_name(type_name, member.name))Type native_read_field_@(member.name) = null;
@@ -208,9 +210,8 @@ public class @(type_name) : IMessage {
 @[    if isinstance(member.type, Array)]@
 
       {
-          int size = native_getsize_array_field_@(member.name)_message(messageHandle);
           @(get_field_name(type_name, member.name)).Clear();
-          for (int i=0; i<size; i++)
+          for (int i = 0; i < @(member.type.size); i++)
           {
 @[        if isinstance(member.type.value_type, BasicType)]
               @(get_field_name(type_name, member.name)).Add(native_read_field_@(member.name)(native_get_field_@(member.name)_message(messageHandle, i)));

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -51,7 +51,7 @@ void * @(msg_prefix)_CDECL @(msg_typename)__get_field_@(member.name)_message(voi
 @(msg_prefix)_EXPORT
 int @(msg_prefix)_CDECL @(msg_typename)__getsize_array_field_@(member.name)_message();
 
-@[        if isinstance(member.type.value_type, BasicType)]@
+@[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
 @(msg_prefix)_EXPORT
 void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.type.value_type)));
 @(msg_prefix)_EXPORT

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -45,10 +45,18 @@ void * @(msg_prefix)_CDECL @(msg_typename)__create_native_message();
 void @(msg_prefix)_CDECL @(msg_typename)__destroy_native_message(void *);
 
 @[for member in message.structure.members]@
-@[    if isinstance(member.type, Array)]@
+@[    if isinstance(member.type, Array) or isinstance(member.type, AbstractSequence)]@
 @(msg_prefix)_EXPORT
 void * @(msg_prefix)_CDECL @(msg_typename)__get_field_@(member.name)_message(void *, int);
 
+@[        if isinstance(member.type, AbstractSequence)]@
+@(msg_prefix)_EXPORT
+int @(msg_prefix)_CDECL @(msg_typename)__getsize_field_@(member.name)_message(void *);
+
+@(msg_prefix)_EXPORT
+bool @(msg_prefix)_CDECL @(msg_typename)__init_sequence_field_@(member.name)_message(void *, int);
+
+@[        end if]@
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
 @(msg_prefix)_EXPORT
 void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.type.value_type)));
@@ -56,8 +64,6 @@ void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.
 @(msg_type_to_c(member.type.value_type)) @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);
 @[        end if]@
 
-@[    elif isinstance(member.type, AbstractSequence)]@
-// TODO: Sequence types are not supported
 @[    elif isinstance(member.type, AbstractWString)]@
 // TODO: Unicode types are not supported
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -48,8 +48,6 @@ void @(msg_prefix)_CDECL @(msg_typename)__destroy_native_message(void *);
 @[    if isinstance(member.type, Array)]@
 @(msg_prefix)_EXPORT
 void * @(msg_prefix)_CDECL @(msg_typename)__get_field_@(member.name)_message(void *, int);
-@(msg_prefix)_EXPORT
-int @(msg_prefix)_CDECL @(msg_typename)__getsize_array_field_@(member.name)_message();
 
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
 @(msg_prefix)_EXPORT

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -47,14 +47,14 @@ void @(msg_prefix)_CDECL @(msg_typename)__destroy_native_message(void *);
 @[for member in message.structure.members]@
 @[    if isinstance(member.type, Array) or isinstance(member.type, AbstractSequence)]@
 @(msg_prefix)_EXPORT
-void * @(msg_prefix)_CDECL @(msg_typename)__get_field_@(member.name)_message(void *, int);
+void * @(msg_prefix)_CDECL @(msg_typename)__get_field_@(member.name)_message(void *, int32_t);
 
 @[        if isinstance(member.type, AbstractSequence)]@
 @(msg_prefix)_EXPORT
-int @(msg_prefix)_CDECL @(msg_typename)__getsize_field_@(member.name)_message(void *);
+int32_t @(msg_prefix)_CDECL @(msg_typename)__getsize_field_@(member.name)_message(void *);
 
 @(msg_prefix)_EXPORT
-bool @(msg_prefix)_CDECL @(msg_typename)__init_sequence_field_@(member.name)_message(void *, int);
+bool @(msg_prefix)_CDECL @(msg_typename)__init_sequence_field_@(member.name)_message(void *, int32_t);
 
 @[        end if]@
 @[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@


### PR DESCRIPTION
This PR was developed without knowing that @ooeygui / ms-iot (pr #87) did similar things.
As this is our (as in [Schiller Automatisierungstechnik GmbH](https://github.com/schiller-de)) first open source contribution, there was some time between writing the code and now publishing and discussing this in the open ;)

# Features added

## Add support for arrays/collections of strings

```C#
test_msgs.msg.Arrays msg = new test_msgs.msg.Arrays();
msg.String_values[0] = "one";
msg.String_values[1] = "two";
msg.String_values[2] = "three";
```

## Add support for collections (unbounded and bounded)

```C#
test_msgs.msg.UnboundedSequences msg = new test_msgs.msg.UnboundedSequences();
msg.Int32_values.Add(24);
msg.Int32_values.Add(25);
msg.Int32_values.Add(26);
```

```C#
test_msgs.msg.BoundedSequences msg = new test_msgs.msg.BoundedSequences();
msg.Int32_values.Add(24);
msg.Int32_values.Add(25);
msg.Int32_values.Add(26);
```

## Add size constants for arrays and bounded sequences

```C#
test_msgs.msg.Arrays msg = new test_msgs.msg.Arrays();
msg.Byte_values = CalcualteExampleArrayWithLength(test_msgs.msg.Arrays.Byte_values_Length)
```

```C#
List<float> floats = GetFloats();
if (floats.Count <= test_msgs.msg.BoundedSequences.Float32_values_MaxCount)
{
    msg.Float32_values = floats;
}
else
{
    // handle error or slice collection...
}
```

## Change mapped class for arrays

Ros arrays are better described with `System.Array` than with `List<T>`.
For example, adding to an array doesn’t make sense as it would violate the length check on publish.

## Initialize arrays with default values

In `rclpy` an `rclcpp` the default is to initialize all members, including arrays.

## Add bounds checks for arrays and bounded sequences

Arrays of wrong size and bounded sequences that exceed the maximum length will throw
an exception on publishing the message.

## Added Tests for all new features

Nothing more to say ;)

# Follow-up adding support for Services

I did continue with implementing services as well. Opend a draft PR #90 which is based on this one.

It will include a fix to `get_error_string` as well, which is the only feature that #87 has added which isn't included in here as far as I reviewed it.
