### PR TITLE
Update ros-tooling actions to fix windows desktop ci

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -11,10 +11,10 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v3
     - name: Setup ROS2
-      uses: ros-tooling/setup-ros@v0.3
+      uses: ros-tooling/setup-ros@v0.6
       with:
         required-ros-distributions: foxy
-    - uses: ros-tooling/action-ros-ci@0.2.4
+    - uses: ros-tooling/action-ros-ci@v0.3
       with:
         package-name: rcldotnet_examples
         target-ros2-distro: foxy


### PR DESCRIPTION
follow up of https://github.com/ros2-dotnet/ros2_dotnet/pull/90#issuecomment-1455191049

This is to see if this fixes master as well.

~~Currently this uses an unrealesed revision of `ros-tooling/setup-ros` that was merged yesterday:~~
- https://github.com/ros-tooling/setup-ros/pull/548