### PR TITLE
Fix warnings about calling conventions

### DIFF
--- a/rcldotnet/rcldotnet_macros.h
+++ b/rcldotnet/rcldotnet_macros.h
@@ -18,11 +18,19 @@
 #if defined(_MSC_VER)
     #define RCLDOTNET_EXPORT __declspec(dllexport)
     #define RCLDOTNET_IMPORT __declspec(dllimport)
-    #define RCLDOTNET_CDECL __cdecl
+    #if defined(_M_IX86)
+        #define RCLDOTNET_CDECL __cdecl
+    #else
+        #define RCLDOTNET_CDECL
+    #endif
 #elif defined(__GNUC__)
     #define RCLDOTNET_EXPORT __attribute__((visibility("default")))
     #define RCLDOTNET_IMPORT
-    #define RCLDOTNET_CDECL __attribute__((__cdecl__))
+    #if defined(__i386__)
+        #define RCLDOTNET_CDECL __attribute__((__cdecl__))
+    #else
+        #define RCLDOTNET_CDECL
+    #endif
 #else
     #define RCLDOTNET_EXPORT
     #define RCLDOTNET_IMPORT

--- a/rcldotnet_examples/CMakeLists.txt
+++ b/rcldotnet_examples/CMakeLists.txt
@@ -23,8 +23,6 @@ set(_assemblies_dep_dlls
     ${std_srvs_ASSEMBLIES_DLL}
 )
 
-message("Included assemblies: ${_assemblies_dep_dlls}")
-
 add_dotnet_executable(rcldotnet_talker
   RCLDotnetTalker.cs
   INCLUDE_DLLS

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -18,12 +18,20 @@ msg_prefix = "RCLDOTNET_{0}_{1}_{2}".format(package_name, '_'.join(message.struc
     //  Microsoft
     #define @(msg_prefix)_EXPORT __declspec(dllexport)
     #define @(msg_prefix)_IMPORT __declspec(dllimport)
-    #define @(msg_prefix)_CDECL __cdecl
+    #if defined(_M_IX86)
+        #define @(msg_prefix)_CDECL __cdecl
+    #else
+        #define @(msg_prefix)_CDECL
+    #endif
 #elif defined(__GNUC__)
     //  GCC
     #define @(msg_prefix)_EXPORT __attribute__((visibility("default")))
     #define @(msg_prefix)_IMPORT
-    #define @(msg_prefix)_CDECL __attribute__((__cdecl__))
+    #if defined(__i386__)
+        #define @(msg_prefix)_CDECL __attribute__((__cdecl__))
+    #else
+        #define @(msg_prefix)_CDECL
+    #endif
 #else
     //  do nothing and hope for the best?
     #define @(msg_prefix)_EXPORT

--- a/rosidl_generator_dotnet/resource/srv.h.em
+++ b/rosidl_generator_dotnet/resource/srv.h.em
@@ -7,12 +7,20 @@ srv_prefix = "RCLDOTNET_{0}_{1}_{2}".format(package_name, '_'.join(service.names
     //  Microsoft
     #define @(srv_prefix)_EXPORT __declspec(dllexport)
     #define @(srv_prefix)_IMPORT __declspec(dllimport)
-    #define @(srv_prefix)_CDECL __cdecl
+    #if defined(_M_IX86)
+        #define @(srv_prefix)_CDECL __cdecl
+    #else
+        #define @(srv_prefix)_CDECL
+    #endif
 #elif defined(__GNUC__)
     //  GCC
     #define @(srv_prefix)_EXPORT __attribute__((visibility("default")))
     #define @(srv_prefix)_IMPORT
-    #define @(srv_prefix)_CDECL __attribute__((__cdecl__))
+    #if defined(__i386__)
+        #define @(srv_prefix)_CDECL __attribute__((__cdecl__))
+    #else
+        #define @(srv_prefix)_CDECL
+    #endif
 #else
     //  do nothing and hope for the best?
     #define @(srv_prefix)_EXPORT


### PR DESCRIPTION
extracted from https://github.com/ros2-dotnet/ros2_dotnet/pull/94

This fixes all `colcon build` warnings for foxi on linux.
There are some new ones for humbe, but they will be fixed seperatly.


```
In file included from /home/stefan/public_git/ros2_dotnet_ws/build/unique_identifier_msgs/rosidl_generator_dotnet/unique_identifier_msgs/msg/uuid.c:20:
/home/stefan/public_git/ros2_dotnet_ws/build/unique_identifier_msgs/rosidl_generator_dotnet/unique_identifier_msgs/msg/rcldotnet_uuid.h:27:1: warning: ‘cdecl’ attribute ignored [-Wattributes]
   27 | const void * RCLDOTNET_UNIQUE_IDENTIFIER_MSGS_UNIQUE_IDENTIFIER_MSGS_MSG_UUID_CDECL unique_identifier_msgs__msg__UUID__get_typesupport();
      | ^~~~~
```

From the commit message:
> This removes a warning when compiling on x64 plattforms.
> The C# DllImportAttribute ignores this calling canvention as well, but dosn't give a warning.