### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -1,5 +1,9 @@
 name: Build (Desktop)
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build-desktop:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,9 +1,9 @@
 name: Build (Linux)
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-linux:

--- a/.github/workflows/build_uwp.yml
+++ b/.github/workflows/build_uwp.yml
@@ -1,9 +1,9 @@
 name: Build (UWP)
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-uwp:

--- a/.github/workflows/ci.repos
+++ b/.github/workflows/ci.repos
@@ -2,7 +2,7 @@ repositories:
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
-    version: master
+    version: main
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/.github/workflows/ci.repos
+++ b/.github/workflows/ci.repos
@@ -26,4 +26,4 @@ repositories:
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ms-iot/dotnet_cmake_module.git
-    version: master
+    version: main

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ can/should be omitted if building on top of a built-from-source ROS2 workspace)
 call \dev\ros2_foxy\local_setup.bat
 md \dev\ros2_dotnet_ws\src
 cd \dev\ros2_dotnet_ws
-curl -sk https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/master/ros2_dotnet_foxy.repos -o ros2_dotnet_foxy.repos
+curl -sk https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/main/ros2_dotnet_foxy.repos -o ros2_dotnet_foxy.repos
 vcs import \dev\ros2_dotnet_ws\src < ros2_dotnet_foxy.repos
 git clone --branch foxy https://github.com/ros2/rosidl src\ros2\rosidl
 colcon build --merge-install
@@ -90,7 +90,7 @@ Assuming ROS2 foxy installed to the standard location, run the following command
 source /opt/ros/foxy/setup.bash
 mkdir -p ~/ros2_dotnet_ws/src
 cd ~/ros2_dotnet_ws
-wget https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/master/ros2_dotnet_foxy.repos
+wget https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/main/ros2_dotnet_foxy.repos
 vcs import ~/ros2_dotnet_ws/src < ros2_dotnet_foxy.repos
 colcon build
 ```
@@ -111,7 +111,7 @@ ament
 ```
 md \dev\ament\src
 cd \dev\ament
-curl -sk https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/master/ament_dotnet_uwp.repos -o ament_dotnet_uwp.repos
+curl -sk https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/main/ament_dotnet_uwp.repos -o ament_dotnet_uwp.repos
 vcs import src < ament_dotnet_uwp.repos
 colcon build --merge-install
 call install\local_setup.bat
@@ -125,7 +125,7 @@ Replace `%TARGET_ARCH%` with Win32 or x64
 ```
 md \dev\ros2\src
 cd \dev\ros2
-curl -sk https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/master/ros2_dotnet_uwp.repos -o ros2_dotnet_uwp.repos
+curl -sk https://raw.githubusercontent.com/ros2-dotnet/ros2_dotnet/main/ros2_dotnet_uwp.repos -o ros2_dotnet_uwp.repos
 vcs import src < ros2_dotnet_uwp.repos
 cd \dev\ament
 call install\local_setup.bat

--- a/ament_dotnet_uwp.repos
+++ b/ament_dotnet_uwp.repos
@@ -30,4 +30,4 @@ repositories:
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
-    version: master
+    version: main

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - main
   paths:
     exclude:
     - README.md

--- a/ros2_dotnet_foxy.repos
+++ b/ros2_dotnet_foxy.repos
@@ -2,7 +2,7 @@ repositories:
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
-    version: master
+    version: main
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2_dotnet_foxy.repos
+++ b/ros2_dotnet_foxy.repos
@@ -30,4 +30,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: master
+    version: main

--- a/ros2_dotnet_foxy.repos
+++ b/ros2_dotnet_foxy.repos
@@ -26,7 +26,7 @@ repositories:
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
-    version: master
+    version: main
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git

--- a/ros2_dotnet_humble.repos
+++ b/ros2_dotnet_humble.repos
@@ -2,7 +2,7 @@ repositories:
   ament_dotnet/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/esteve/ament_cmake_export_assemblies.git
-    version: master
+    version: main
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2_dotnet_humble.repos
+++ b/ros2_dotnet_humble.repos
@@ -30,4 +30,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: master
+    version: main

--- a/ros2_dotnet_humble.repos
+++ b/ros2_dotnet_humble.repos
@@ -26,7 +26,7 @@ repositories:
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
-    version: master
+    version: main
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -98,7 +98,7 @@ repositories:
   ros2_dotnet/dotnet_cmake_module:
     type: git
     url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
-    version: master
+    version: main
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git

--- a/ros2_dotnet_uwp.repos
+++ b/ros2_dotnet_uwp.repos
@@ -102,4 +102,4 @@ repositories:
   ros2_dotnet/ros2_dotnet:
     type: git
     url: https://github.com/ros2-dotnet/ros2_dotnet.git
-    version: master
+    version: main


### PR DESCRIPTION
Now we sould be able to rename the master branches of the following repos:
- https://github.com/ros2-dotnet/ros2_dotnet
- https://github.com/ros2-dotnet/dotnet_cmake_module
- https://github.com/esteve/ament_cmake_export_assemblies

@esteve should `ament_cmake_export_assemblies` be moved to the `ros2-dotnet` organization? [Seems like both repositories where created on your user](https://github.com/ros2-dotnet/ros2_dotnet/commit/31074ee02a18c8f31b6c6b3748c9bb897226f308), but you only moved `dotnet_cmake_module` to the `ros2-dotnet` organization.