### PR TITLE
Fix marshalling bool parameters and return values in pInvokes

### DIFF
--- a/rcldotnet/Client.cs
+++ b/rcldotnet/Client.cs
@@ -33,7 +33,7 @@ namespace ROS2
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate RCLRet NativeRCLServiceServerIsAvailableType(
-            SafeNodeHandle nodeHandle, SafeClientHandle clientHandle, out bool isAvailable);
+            SafeNodeHandle nodeHandle, SafeClientHandle clientHandle, out int isAvailable);
 
         internal static NativeRCLServiceServerIsAvailableType native_rcl_service_server_is_available = null;
 
@@ -95,10 +95,10 @@ namespace ROS2
 
         public bool ServiceIsReady()
         {
-            RCLRet ret = ClientDelegates.native_rcl_service_server_is_available(_node.Handle, Handle, out var serviceIsReady);
+            RCLRet ret = ClientDelegates.native_rcl_service_server_is_available(_node.Handle, Handle, out int serviceIsReady);
             RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(ClientDelegates.native_rcl_service_server_is_available)}() failed.");
 
-            return serviceIsReady;
+            return serviceIsReady != 0;
         }
 
         public Task<TResponse> SendRequestAsync(TRequest request)

--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -40,7 +40,7 @@ namespace ROS2
         internal static NativeRCLResetErrorType native_rcl_reset_error = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLOkType();
+        internal delegate int NativeRCLOkType();
 
         internal static NativeRCLOkType native_rcl_ok = null;
 
@@ -117,22 +117,22 @@ namespace ROS2
         internal static NativeRCLWaitType native_rcl_wait = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetSubscriptionReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetSubscriptionReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetSubscriptionReady native_rcl_wait_set_subscription_ready = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetClientReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetClientReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetClientReady native_rcl_wait_set_client_ready = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetServiceReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetServiceReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetServiceReady native_rcl_wait_set_service_ready = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetGuardConditionReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetGuardConditionReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetGuardConditionReady native_rcl_wait_set_guard_condition_ready = null;
 
@@ -354,7 +354,7 @@ namespace ROS2
 
         public static bool Ok()
         {
-            return RCLdotnetDelegates.native_rcl_ok();
+            return RCLdotnetDelegates.native_rcl_ok() != 0;
         }
 
         public static Node CreateNode(string nodeName)
@@ -676,7 +676,7 @@ namespace ROS2
                 int subscriptionIndex = 0;
                 foreach (Subscription subscription in node.Subscriptions)
                 {
-                    if (RCLdotnetDelegates.native_rcl_wait_set_subscription_ready(waitSetHandle, subscriptionIndex))
+                    if (RCLdotnetDelegates.native_rcl_wait_set_subscription_ready(waitSetHandle, subscriptionIndex) != 0)
                     {
                         IRosMessage message = subscription.CreateMessage();
                         bool result = Take(subscription, message);
@@ -695,7 +695,7 @@ namespace ROS2
                     int serviceIndex = 0;
                     foreach (var service in node.Services)
                     {
-                        if (RCLdotnetDelegates.native_rcl_wait_set_service_ready(waitSetHandle, serviceIndex))
+                        if (RCLdotnetDelegates.native_rcl_wait_set_service_ready(waitSetHandle, serviceIndex) != 0)
                         {
                             var request = service.CreateRequest();
                             var response = service.CreateResponse();
@@ -715,7 +715,7 @@ namespace ROS2
                     int clientIndex = 0;
                     foreach (var client in node.Clients)
                     {
-                        if (RCLdotnetDelegates.native_rcl_wait_set_client_ready(waitSetHandle, clientIndex))
+                        if (RCLdotnetDelegates.native_rcl_wait_set_client_ready(waitSetHandle, clientIndex) != 0)
                         {
                             var response = client.CreateResponse();
 
@@ -734,7 +734,7 @@ namespace ROS2
                 int guardConditionIndex = 0;
                 foreach (GuardCondition guardCondition in node.GuardConditions)
                 {
-                    if (RCLdotnetDelegates.native_rcl_wait_set_guard_condition_ready(waitSetHandle, guardConditionIndex))
+                    if (RCLdotnetDelegates.native_rcl_wait_set_guard_condition_ready(waitSetHandle, guardConditionIndex) != 0)
                     {
                         guardCondition.TriggerCallback();
                     }

--- a/rcldotnet/rcldotnet.c
+++ b/rcldotnet/rcldotnet.c
@@ -57,7 +57,10 @@ void native_rcl_reset_error(void) {
   rcl_reset_error();
 }
 
-bool native_rcl_ok() { return rcl_context_is_valid(&context); }
+int32_t native_rcl_ok() {
+  bool result = rcl_context_is_valid(&context);
+  return result ? 1 : 0;
+}
 
 int32_t native_rcl_create_node_handle(void **node_handle, const char *name, const char *namespace) {
   rcl_node_t *node = (rcl_node_t *)malloc(sizeof(rcl_node_t));
@@ -178,7 +181,7 @@ int32_t native_rcl_wait(void *wait_set_handle, int64_t timeout) {
   return ret;
 }
 
-bool native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_subscriptions)
@@ -186,10 +189,11 @@ bool native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index
     return false;
   }
 
-  return wait_set->subscriptions[index] != NULL;
+  bool result = wait_set->subscriptions[index] != NULL;
+  return result ? 1 : 0;
 }
 
-bool native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_clients)
@@ -197,10 +201,11 @@ bool native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index) {
     return false;
   }
 
-  return wait_set->clients[index] != NULL;
+  bool result = wait_set->clients[index] != NULL;
+  return result ? 1 : 0;
 }
 
-bool native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_services)
@@ -208,10 +213,11 @@ bool native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index) {
     return false;
   }
 
-  return wait_set->services[index] != NULL;
+  bool result = wait_set->services[index] != NULL;
+  return result ? 1 : 0;
 }
 
-bool native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_guard_conditions)
@@ -219,7 +225,8 @@ bool native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t in
     return false;
   }
 
-  return wait_set->guard_conditions[index] != NULL;
+  bool result = wait_set->guard_conditions[index] != NULL;
+  return result ? 1 : 0;
 }
 
 int32_t native_rcl_take(void *subscription_handle, void *message_handle) {

--- a/rcldotnet/rcldotnet.h
+++ b/rcldotnet/rcldotnet.h
@@ -30,7 +30,7 @@ RCLDOTNET_EXPORT
 void RCLDOTNET_CDECL native_rcl_reset_error(void);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_ok();
+int32_t RCLDOTNET_CDECL native_rcl_ok();
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_create_node_handle(void **, const char *, const char *);
@@ -76,16 +76,16 @@ RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_wait(void *, int64_t);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_take(void *, void *);

--- a/rcldotnet/rcldotnet_client.c
+++ b/rcldotnet/rcldotnet_client.c
@@ -34,10 +34,13 @@ int32_t native_rcl_send_request(void *client_handle, void *request_handle, int64
   return ret;
 }
 
-int32_t native_rcl_service_server_is_available(void *node_handle, void *client_handle, bool *is_available) {
+int32_t native_rcl_service_server_is_available(void *node_handle, void *client_handle, int32_t *is_available) {
   rcl_node_t * node = (rcl_node_t *)node_handle;
   rcl_client_t * client = (rcl_client_t *)client_handle;
 
-  rcl_ret_t ret = rcl_service_server_is_available(node, client, is_available);
+  bool is_available_as_bool;
+  rcl_ret_t ret = rcl_service_server_is_available(node, client, &is_available_as_bool);
+  *is_available = is_available_as_bool ? 1 : 0;
+
   return ret;
 }

--- a/rcldotnet/rcldotnet_client.h
+++ b/rcldotnet/rcldotnet_client.h
@@ -21,6 +21,6 @@ RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_send_request(void *client_handle, void *request_handle, int64_t *sequence_number);
 
 RCLDOTNET_EXPORT
-int32_t RCLDOTNET_CDECL native_rcl_service_server_is_available(void *node_handle, void *client_handle, bool *is_available);
+int32_t RCLDOTNET_CDECL native_rcl_service_server_is_available(void *node_handle, void *client_handle, int32_t *is_available);
 
 #endif // RCLDOTNET_CLIENT_H

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -7,6 +7,7 @@ from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import BOOLEAN_TYPE
 from rosidl_generator_dotnet import msg_type_to_c
 
 type_name = message.structure.namespaced_type.name
@@ -62,7 +63,13 @@ int32_t @(msg_prefix)_CDECL @(msg_typename)__getsize_field_@(member.name)_messag
 bool @(msg_prefix)_CDECL @(msg_typename)__init_sequence_field_@(member.name)_message(void *, int32_t);
 
 @[        end if]@
-@[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == BOOLEAN_TYPE]@
+@# Special handling for marshaling bool as int32_t
+@(msg_prefix)_EXPORT
+void @(msg_typename)__write_field_@(member.name)(void *, int32_t /* bool */);
+@(msg_prefix)_EXPORT
+int32_t /* bool */ @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);
+@[        elif isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
 @(msg_prefix)_EXPORT
 void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.type.value_type)));
 @(msg_prefix)_EXPORT
@@ -71,6 +78,13 @@ void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.
 
 @[    elif isinstance(member.type, AbstractWString)]@
 // TODO: Unicode types are not supported
+@[    elif isinstance(member.type, BasicType) and member.type.typename == BOOLEAN_TYPE]@
+@# Special handling for marshaling bool as int32_t
+@(msg_prefix)_EXPORT
+int32_t /* bool */ @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);
+
+@(msg_prefix)_EXPORT
+void @(msg_typename)__write_field_@(member.name)(void *, int32_t /* bool */);
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
 @(msg_prefix)_EXPORT
 @(msg_type_to_c(member.type)) @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);


### PR DESCRIPTION
extracted from https://github.com/ros2-dotnet/ros2_dotnet/pull/94

This fixes Issues with bools that where interpreted wrong in release builds and therefore causing wrong behavior.

See https://www.mono-project.com/docs/advanced/pinvoke/#boolean-membersfor more information on marshalling bools.

Took the following path:
- Use `int` on C# side and `int32_t` on the c side instead of bool for the library code to make this as explicit as it gets and avoid `bool` entirely.
- Use `bool` on C# side and `int32_t` on the c side in the messages code. This avoids having to ad special cases to the C# template for the code generation. As `bool`s in C# pInvokes get marshalled as 32 bit integer by default there is no need to change the code for `bool` fields.