### PR TITLE
Add Quality of Service (QoS) to publishers and subscribers

### DIFF
--- a/rcldotnet/CMakeLists.txt
+++ b/rcldotnet/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CS_SOURCES
   MessageStaticMemberCache.cs
   Node.cs
   Publisher.cs
+  QosProfile.cs
   RCLdotnet.cs
   RCLExceptionHelper.cs
   RCLRet.cs
@@ -40,6 +41,7 @@ set(CS_SOURCES
   SafeGuardConditionHandle.cs
   SafeNodeHandle.cs
   SafePublisherHandle.cs
+  SafeQosProfileHandle.cs
   SafeRequestIdHandle.cs
   SafeServiceHandle.cs
   SafeSubscriptionHandle.cs

--- a/rcldotnet/QosProfile.cs
+++ b/rcldotnet/QosProfile.cs
@@ -1,0 +1,566 @@
+/* Copyright 2022 Stefan Hoffmann <stefan.hoffmann@schiller.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Threading;
+
+namespace ROS2
+{
+    /// <summary>
+    /// The `HISTORY` DDS QoS policy.
+    ///
+    /// A subscription internally maintains a queue of messages (called "samples" in DDS) that have not
+    /// been processed yet by the application, and likewise a publisher internally maintains a queue.
+    ///
+    /// If the history policy is `KeepAll`, this queue is unbounded, and if it is `KeepLast`, it is
+    /// bounded and old values are discarded when the queue is overfull.
+    ///
+    /// # Compatibility
+    /// | Publisher | Subscription | Compatible |
+    /// | --------- | ------------ | ---------- |
+    /// | KeepLast  | KeepLast     | yes        |
+    /// | KeepLast  | KeepAll      | yes        |
+    /// | KeepAll   | KeepLast     | yes        |
+    /// | KeepAll   | KeepAll      | yes        |
+    /// </summary>
+    public enum QosHistoryPolicy
+    {
+        /// <summary>
+        /// Implementation default for history policy.
+        /// </summary>
+        SystemDefault = 0,
+
+        /// <summary>
+        /// Only store up to a maximum number of samples, dropping oldest once max is exceeded.
+        /// </summary>
+        KeepLast = 1,
+
+        /// <summary>
+        /// Store all samples, subject to resource limits.
+        /// </summary>
+        KeepAll = 2,
+    }
+
+    /// <summary>
+    /// The `RELIABILITY` DDS QoS policy.
+    ///
+    /// This policy determines whether delivery between a publisher and a subscription will be retried
+    /// until successful, or whether messages may be lost in a trade off for better performance.
+    ///
+    /// # Compatibility
+    /// | Publisher  | Subscription | Compatible | Behavior    |
+    /// | ---------- | ------------ | ---------- | ----------- |
+    /// | Reliable   | Reliable     | yes        | Reliable    |
+    /// | Reliable   | BestEffort   | yes        | Best effort |
+    /// | BestEffort | Reliable     | no         | -           |
+    /// | BestEffort | BestEffort   | yes        | Best effort |
+    /// </summary>
+    public enum QosReliabilityPolicy
+    {
+        /// <summary>
+        /// Use the default policy of the RMW layer.
+        /// </summary>
+        SystemDefault = 0,
+
+        /// <summary>
+        /// Guarantee delivery of messages.
+        /// </summary>
+        Reliable = 1,
+
+        /// <summary>
+        /// Send messages but do not guarantee delivery.
+        /// </summary>
+        BestEffort = 2,
+    }
+
+    /// <summary>
+    /// The `DURABILITY` DDS QoS policy.
+    ///
+    /// If a subscription is created after some messages have already been published, it is possible
+    /// for the subscription to receive a number of previously-published messages by using the
+    /// "transient local" durability kind on both ends. For this, the publisher must still exist when
+    /// the subscription is created.
+    ///
+    /// # Compatibility
+    /// | Publisher      | Subscription   | Compatible | Behavior                                  |
+    /// | -------------- | -------------- | ---------- | ----------------------------------------- |
+    /// | TransientLocal | TransientLocal | yes        | Deliver old messages to new subscriptions |
+    /// | TransientLocal | Volatile       | yes        | Deliver only new messages                 |
+    /// | Volatile       | TransientLocal | no         | -                                         |
+    /// | Volatile       | Volatile       | yes        | Deliver only new messages                 |
+    /// </summary>
+    public enum QosDurabilityPolicy
+    {
+        /// <summary>
+        /// Use the default policy of the RMW layer.
+        /// </summary>
+        SystemDefault = 0,
+
+        /// <summary>
+        /// Re-deliver old messages.
+        /// - For publishers: Retain messages for later delivery.
+        /// - For subscriptions: Request delivery of old messages.
+        /// </summary>
+        TransientLocal = 1,
+
+        /// <summary>
+        /// Do not retain/request old messages.
+        /// </summary>
+        Volatile = 2,
+    }
+
+    /// <summary>
+    /// The `LIVELINESS` DDS QoS policy.
+    ///
+    /// This policy describes a publisher's reporting policy for its alive status.
+    /// For a subscription, these are its requirements for its topic's publishers.
+    ///
+    /// # Compatibility
+    /// | Publisher     | Subscription  | Compatible |
+    /// | ------------- | ------------- | ---------- |
+    /// | Automatic     | Automatic     | yes        |
+    /// | Automatic     | ManualByTopic | no         |
+    /// | ManualByTopic | Automatic     | yes        |
+    /// | ManualByTopic | ManualByTopic | yes        |
+    /// </summary>
+    public enum QosLivelinessPolicy
+    {
+        /// <summary>
+        /// Use the default policy of the RMW layer.
+        /// </summary>
+        SystemDefault = 0,
+
+        /// <summary>
+        /// The signal that establishes that a topic is alive comes from the ROS `rmw` layer.
+        /// </summary>
+        Automatic = 1,
+
+        /// <summary>
+        /// The signal that establishes that a topic is alive is sent explicitly. Only publishing a message
+        /// on the topic or an explicit signal from the application to assert liveliness on the topic
+        /// will mark the topic as being alive.
+        /// </summary>
+        ManualByTopic = 3,
+    }
+
+    /// <summary>
+    /// A Quality of Service profile.
+    ///
+    /// See [docs.ros.org][1] on Quality of Service settings in general.
+    ///
+    /// In the general case, a topic can have multiple publishers and multiple subscriptions, each with
+    /// an individual QoS profile. For each publisher-subscription pair, messages are only delivered if
+    /// their QoS profiles are compatible.
+    ///
+    /// [1]: https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
+    /// </summary>
+    public sealed class QosProfile
+    {
+        // This is private to force use of factory methods.
+        private QosProfile(
+            QosHistoryPolicy history,
+            int depth,
+            QosReliabilityPolicy reliability,
+            QosDurabilityPolicy durability,
+            TimeSpan deadline,
+            TimeSpan lifespan,
+            QosLivelinessPolicy liveliness,
+            TimeSpan livelinessLeaseDuration,
+            bool avoidRosNamespaceConventions)
+        {
+            History = history;
+            Depth = depth;
+            Reliability = reliability;
+            Durability = durability;
+            Deadline = deadline;
+            Lifespan = lifespan;
+            Liveliness = liveliness;
+            LivelinessLeaseDuration = livelinessLeaseDuration;
+            AvoidRosNamespaceConventions = avoidRosNamespaceConventions;
+        }
+
+        // RMW_DURATION_INFINITE is defined as INT64_MAX nanoseconds, which does
+        // not map nicely to TimeSpan as it uses 100ns ticks as representation.
+        //
+        // So this uses Timeout.InfiniteTimeSpan as special value.
+        // Timeout.InfiniteTimeSpan is defined as -1ms. This does not collide
+        // with the rmw_time_t values as it is defined as unsigned integers for
+        // seconds.
+
+        /// <summary>
+        /// Special value for TimeSpan to indicate Infinite on all TimeSpan
+        /// properties fo this class.
+        /// </summary>
+        public static TimeSpan InfiniteDuration => Timeout.InfiniteTimeSpan;
+
+        /// <summary>
+        /// The default QoS profile.
+        /// </summary>
+        public static QosProfile DefaultProfile { get; } = CreateDefaultProfile();
+
+        /// <summary>
+        /// The history policy.
+        /// </summary>
+        public QosHistoryPolicy History { get; }
+
+        /// <summary>
+        /// Size of the message queue.
+        /// </summary>
+        public int Depth { get; }
+
+        /// <summary>
+        /// The reliability policy.
+        /// </summary>
+        public QosReliabilityPolicy Reliability { get; }
+
+        /// <summary>
+        /// The durability policy.
+        /// </summary>
+        public QosDurabilityPolicy Durability { get; }
+
+        /// <summary>
+        /// The period at which messages are expected to be sent/received.
+        ///
+        /// If this is <see cref="QosProfile.InfiniteDuration">, messages never miss a deadline expectation.
+        /// </summary>
+        public TimeSpan Deadline { get; }
+
+        /// <summary>
+        /// The age at which messages are considered expired and no longer valid.
+        ///
+        /// If this is <see cref="QosProfile.InfiniteDuration">, messages do not expire.
+        /// </summary>
+        public TimeSpan Lifespan { get; }
+
+        /// <summary>
+        /// The liveliness policy.
+        /// </summary>
+        public QosLivelinessPolicy Liveliness { get; }
+
+        /// <summary>
+        /// The time within which the RMW publisher must show that it is alive.
+        ///
+        /// If this is <see cref="QosProfile.InfiniteDuration">, liveliness is not enforced.
+        /// </summary>
+        public TimeSpan LivelinessLeaseDuration { get; }
+
+        /// <summary>
+        /// If true, any ROS specific namespacing conventions will be circumvented.
+        ///
+        /// In the case of DDS and topics, for example, this means the typical
+        /// ROS specific prefix of `rt` would not be applied as described [here][1].
+        ///
+        /// This might be useful when trying to directly connect a native DDS topic
+        /// with a ROS 2 topic.
+        ///
+        /// [1]: http://design.ros2.org/articles/topic_and_service_names.html#ros-specific-namespace-prefix
+        /// </summary>
+        public bool AvoidRosNamespaceConventions { get; }
+
+        /// <summary>
+        /// Create a new QosProfile with the history set to KeepLast and the given depth.
+        /// </summary>
+        /// <param name="depth">Size of the message queue.</param>
+        public static QosProfile KeepLast(int depth)
+        {
+            return DefaultProfile.WithKeepLast(depth);
+        }
+
+        /// <summary>
+        /// Create a new QosProfile with the history set to KeepAll.
+        /// </summary>
+        public static QosProfile KeepAll()
+        {
+            return DefaultProfile.WithKeepAll();
+        }
+
+        /// <summary>
+        /// Set the history to KeepLast and the given depth.
+        /// </summary>
+        /// <param name="depth">Size of the message queue.</param>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithKeepLast(int depth)
+        {
+            return WithHistoryAndDepth(QosHistoryPolicy.KeepLast, depth);
+        }
+
+        /// <summary>
+        /// Set the history to KeepAll.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithKeepAll()
+        {
+            return WithHistoryAndDepth(QosHistoryPolicy.KeepAll, depth: 0);
+        }
+
+        // This is private to disallow invalid combination off values.
+        private QosProfile WithHistoryAndDepth(QosHistoryPolicy history, int depth)
+        {
+            var result = new QosProfile(
+                history: history,
+                depth: depth,
+                reliability: Reliability,
+                durability: Durability,
+                deadline: Deadline,
+                lifespan: Lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="Reliability">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithReliability(QosReliabilityPolicy reliability)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: reliability,
+                durability: Durability,
+                deadline: Deadline,
+                lifespan: Lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="Reliability"> to <see cref="QosReliabilityPolicy.Reliable">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithReliable() => WithReliability(QosReliabilityPolicy.Reliable);
+
+        /// <summary>
+        /// Set the <see cref="Reliability"> to <see cref="QosReliabilityPolicy.BestEffort">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithBestEffort() => WithReliability(QosReliabilityPolicy.BestEffort);
+
+        /// <summary>
+        /// Set the <see cref="Durability">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithDurability(QosDurabilityPolicy durability)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: Reliability,
+                durability: durability,
+                deadline: Deadline,
+                lifespan: Lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="Durability"> to <see cref="QosDurabilityPolicy.TransientLocal">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithTransientLocal() => WithDurability(QosDurabilityPolicy.TransientLocal);
+
+        /// <summary>
+        /// Set the <see cref="Volatile"> to <see cref="QosDurabilityPolicy.Volatile">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithVolatile() => WithDurability(QosDurabilityPolicy.Volatile);
+
+        /// <summary>
+        /// Set the <see cref="Deadline">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithDeadline(TimeSpan deadline)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: Reliability,
+                durability: Durability,
+                deadline: deadline,
+                lifespan: Lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="Lifespan">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithLifespan(TimeSpan lifespan)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: Reliability,
+                durability: Durability,
+                deadline: Deadline,
+                lifespan: lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="Liveliness">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithLiveliness(QosLivelinessPolicy liveliness)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: Reliability,
+                durability: Durability,
+                deadline: Deadline,
+                lifespan: Lifespan,
+                liveliness: liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="LivelinessLeaseDuration">.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithLivelinessLeaseDuration(TimeSpan livelinessLeaseDuration)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: Reliability,
+                durability: Durability,
+                deadline: Deadline,
+                lifespan: Lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: livelinessLeaseDuration,
+                avoidRosNamespaceConventions: AvoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set the <see cref="AvoidRosNamespaceConventions"> value.
+        /// </summary>
+        /// <returns>A new QosProfile with the modification.</returns>
+        public QosProfile WithAvoidRosNamespaceConventions(bool avoidRosNamespaceConventions)
+        {
+            var result = new QosProfile(
+                history: History,
+                depth: Depth,
+                reliability: Reliability,
+                durability: Durability,
+                deadline: Deadline,
+                lifespan: Lifespan,
+                liveliness: Liveliness,
+                livelinessLeaseDuration: LivelinessLeaseDuration,
+                avoidRosNamespaceConventions: avoidRosNamespaceConventions);
+
+            return result;
+        }
+
+        private static QosProfile CreateDefaultProfile()
+        {
+            // taken from rmw_qos_profile_default
+            // TODO: (sh) read values from rmw layer instead of hardcoding them here.
+
+            var result = new QosProfile(
+                history: QosHistoryPolicy.KeepLast,
+                depth: 10,
+                reliability: QosReliabilityPolicy.Reliable,
+                durability: QosDurabilityPolicy.Volatile,
+                deadline: TimeSpan.Zero,
+                lifespan: TimeSpan.Zero,
+                liveliness: QosLivelinessPolicy.SystemDefault,
+                livelinessLeaseDuration: TimeSpan.Zero,
+                avoidRosNamespaceConventions: false);
+
+            return result;
+        }
+
+        internal static SafeQosProfileHandle CreateQosProfileHandle()
+        {
+            var qosProfileHandle = new SafeQosProfileHandle();
+            RCLRet ret = RCLdotnetDelegates.native_rcl_create_qos_profile_handle(ref qosProfileHandle);
+            if (ret != RCLRet.Ok)
+            {
+                qosProfileHandle.Dispose();
+                throw RCLExceptionHelper.CreateFromReturnValue(ret, $"{nameof(RCLdotnetDelegates.native_rcl_create_qos_profile_handle)}() failed.");
+            }
+
+            return qosProfileHandle;
+        }
+
+        internal static void WriteToQosProfileHandle(QosProfile qosProfile, SafeQosProfileHandle qosProfileHandle)
+        {
+            ToRmwTime(qosProfile.Deadline, out ulong deadlineSec, out ulong deadlineNsec);
+            ToRmwTime(qosProfile.Lifespan, out ulong lifespanSec, out ulong lifespanNsec);
+            ToRmwTime(qosProfile.LivelinessLeaseDuration, out ulong livelinessLeaseDurationSec, out ulong livelinessLeaseDurationNsec);
+
+            RCLRet ret = RCLdotnetDelegates.native_rcl_write_to_qos_profile_handle(qosProfileHandle,
+                history: (int)qosProfile.History,
+                depth: qosProfile.Depth,
+                reliability: (int)qosProfile.Reliability,
+                durability: (int)qosProfile.Durability,
+                deadlineSec: deadlineSec,
+                deadlineNsec: deadlineNsec,
+                lifespanSec: lifespanSec,
+                lifespanNsec: lifespanNsec,
+                liveliness: (int)qosProfile.Liveliness,
+                livelinessLeaseDurationSec: livelinessLeaseDurationSec,
+                livelinessLeaseDurationNsec: livelinessLeaseDurationNsec,
+                avoidRosNamespaceConventions: qosProfile.AvoidRosNamespaceConventions ? 1 : 0);
+
+            RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(RCLdotnetDelegates.native_rcl_write_to_qos_profile_handle)}() failed.");
+        }
+
+        private static void ToRmwTime(TimeSpan timeSpan, out ulong sec, out ulong nsec)
+        {
+            if (timeSpan == InfiniteDuration)
+            {
+                // see RMW_DURATION_INFINITE and comment on QosProfile.InfiniteDuration above.
+                sec = 9223372036;
+                nsec = 854775807;
+                return;
+            }
+
+            const long NanosecondsPerSecond = 1_000_000_000;
+            const long NanosecondsPerTick = NanosecondsPerSecond / TimeSpan.TicksPerSecond;
+
+            long ticks = timeSpan.Ticks;
+            long seconds = ticks / TimeSpan.TicksPerSecond;
+            long ticksRoundedDownToFullSecond = seconds * TimeSpan.TicksPerSecond;
+            long ticksInsideSecond = ticks - ticksRoundedDownToFullSecond;
+
+            sec = (ulong)seconds;
+            nsec = (ulong)(ticksInsideSecond * NanosecondsPerTick);
+        }
+    }
+}

--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -172,6 +172,32 @@ namespace ROS2
 
         internal static NativeRCLTakeResponseType native_rcl_take_response = null;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate RCLRet NativeRCLCreateQosProfileHandleType(ref SafeQosProfileHandle qosProfileHandle);
+        internal static NativeRCLCreateQosProfileHandleType native_rcl_create_qos_profile_handle = null;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate RCLRet NativeRCLDestroyQosProfileHandleType(IntPtr qosProfileHandle);
+        internal static NativeRCLDestroyQosProfileHandleType native_rcl_destroy_qos_profile_handle = null;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate RCLRet NativeRCLWriteToQosProfileHandleType(
+            SafeQosProfileHandle qosProfileHandle,
+            int history,
+            int depth,
+            int reliability,
+            int durability,
+            ulong deadlineSec,
+            ulong deadlineNsec,
+            ulong lifespanSec,
+            ulong lifespanNsec,
+            int liveliness,
+            ulong livelinessLeaseDurationSec,
+            ulong livelinessLeaseDurationNsec,
+            int avoidRosNamespaceConventions);
+
+        internal static NativeRCLWriteToQosProfileHandleType native_rcl_write_to_qos_profile_handle = null;
+
         static RCLdotnetDelegates()
         {
             _dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
@@ -344,6 +370,24 @@ namespace ROS2
             RCLdotnetDelegates.native_rcl_take_response =
                 (NativeRCLTakeResponseType)Marshal.GetDelegateForFunctionPointer(
                     native_rcl_take_response_ptr, typeof(NativeRCLTakeResponseType));
+
+            IntPtr native_rcl_create_qos_profile_handle_ptr =
+                _dllLoadUtils.GetProcAddress(nativeLibrary, "native_rcl_create_qos_profile_handle");
+            RCLdotnetDelegates.native_rcl_create_qos_profile_handle =
+                (NativeRCLCreateQosProfileHandleType)Marshal.GetDelegateForFunctionPointer(
+                    native_rcl_create_qos_profile_handle_ptr, typeof(NativeRCLCreateQosProfileHandleType));
+
+            IntPtr native_rcl_destroy_qos_profile_handle_ptr =
+                _dllLoadUtils.GetProcAddress(nativeLibrary, "native_rcl_destroy_qos_profile_handle");
+            RCLdotnetDelegates.native_rcl_destroy_qos_profile_handle =
+                (NativeRCLDestroyQosProfileHandleType)Marshal.GetDelegateForFunctionPointer(
+                    native_rcl_destroy_qos_profile_handle_ptr, typeof(NativeRCLDestroyQosProfileHandleType));
+
+            IntPtr native_rcl_write_to_qos_profile_handle_ptr =
+                _dllLoadUtils.GetProcAddress(nativeLibrary, "native_rcl_write_to_qos_profile_handle");
+            RCLdotnetDelegates.native_rcl_write_to_qos_profile_handle =
+                (NativeRCLWriteToQosProfileHandleType)Marshal.GetDelegateForFunctionPointer(
+                    native_rcl_write_to_qos_profile_handle_ptr, typeof(NativeRCLWriteToQosProfileHandleType));
         }
     }
 

--- a/rcldotnet/SafeQosProfileHandle.cs
+++ b/rcldotnet/SafeQosProfileHandle.cs
@@ -1,0 +1,43 @@
+/* Copyright 2022 Stefan Hoffmann <stefan.hoffmann@schiller.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Diagnostics;
+using Microsoft.Win32.SafeHandles;
+
+namespace ROS2
+{
+    /// <summary>
+    /// Safe handle representing a rmw_qos_profile_t
+    /// </summary>
+    internal sealed class SafeQosProfileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public static readonly SafeQosProfileHandle Null = new SafeQosProfileHandle();
+
+        public SafeQosProfileHandle()
+            : base(ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            RCLRet ret = RCLdotnetDelegates.native_rcl_destroy_qos_profile_handle(handle);
+            bool successfullyFreed = ret == RCLRet.Ok;
+
+            Debug.Assert(successfullyFreed);
+
+            return successfullyFreed;
+        }
+    }
+}

--- a/rcldotnet/rcldotnet.c
+++ b/rcldotnet/rcldotnet.c
@@ -278,3 +278,52 @@ int32_t native_rcl_take_response(void *client_handle, void *request_header_handl
   return ret;
 }
 
+int32_t native_rcl_create_qos_profile_handle(void **qos_profile_handle)
+{
+  rmw_qos_profile_t *qos_profile = (rmw_qos_profile_t *)malloc(sizeof(rmw_qos_profile_t));
+  *qos_profile = rmw_qos_profile_default;
+  *qos_profile_handle = (void *)qos_profile;
+
+  return RCL_RET_OK;
+}
+
+int32_t native_rcl_destroy_qos_profile_handle(void *qos_profile_handle)
+{
+  rmw_qos_profile_t *qos_profile = (rmw_qos_profile_t *)qos_profile_handle;
+  free(qos_profile);
+
+  return RCL_RET_OK;
+}
+
+int32_t native_rcl_write_to_qos_profile_handle(
+    void *qos_profile_handle,
+    int32_t history,
+    int32_t depth,
+    int32_t reliability,
+    int32_t durability,
+    uint64_t deadline_sec,
+    uint64_t deadline_nsec,
+    uint64_t lifespan_sec,
+    uint64_t lifespan_nsec,
+    int32_t liveliness,
+    uint64_t liveliness_lease_duration_sec,
+    uint64_t liveliness_lease_duration_nsec,
+    int32_t /* bool */ avoid_ros_namespace_conventions)
+{
+  rmw_qos_profile_t *qos_profile = (rmw_qos_profile_t *)qos_profile_handle;
+
+  qos_profile->history = (enum rmw_qos_history_policy_t)history;
+  qos_profile->depth = (size_t)depth;
+  qos_profile->reliability = (enum rmw_qos_reliability_policy_t)reliability;
+  qos_profile->durability = (enum rmw_qos_durability_policy_t)durability;
+  qos_profile->deadline.sec = deadline_sec;
+  qos_profile->deadline.nsec = deadline_nsec;
+  qos_profile->lifespan.sec = lifespan_sec;
+  qos_profile->lifespan.nsec = lifespan_nsec;
+  qos_profile->liveliness = (enum rmw_qos_liveliness_policy_t)liveliness;
+  qos_profile->liveliness_lease_duration.sec = liveliness_lease_duration_sec;
+  qos_profile->liveliness_lease_duration.nsec = liveliness_lease_duration_nsec;
+  qos_profile->avoid_ros_namespace_conventions = avoid_ros_namespace_conventions != 0;
+
+  return RCL_RET_OK;
+}

--- a/rcldotnet/rcldotnet.c
+++ b/rcldotnet/rcldotnet.c
@@ -312,15 +312,23 @@ int32_t native_rcl_write_to_qos_profile_handle(
 {
   rmw_qos_profile_t *qos_profile = (rmw_qos_profile_t *)qos_profile_handle;
 
-  qos_profile->history = (enum rmw_qos_history_policy_t)history;
+  // Can't name the enums for both Foxy and Humble the in code.
+  // So use implicit conversions for now...
+  // This breaking change was introduced in https://github.com/ros2/rmw/commit/05f973575e8e93454e39f51da6227509061ff189
+  // In Foxy they are defined as `enum rmw_qos_history_policy_t { ... };
+  //   -> so the type is called `enum rmw_qos_history_policy_t`
+  // In Humble tey are defined as `typedef enum rmw_qos_history_policy_e { ... } rmw_qos_history_policy_t;
+  //   -> so the type is called `rmw_qos_history_policy_t`
+
+  qos_profile->history = /* (rmw_qos_history_policy_t) */ history;
   qos_profile->depth = (size_t)depth;
-  qos_profile->reliability = (enum rmw_qos_reliability_policy_t)reliability;
-  qos_profile->durability = (enum rmw_qos_durability_policy_t)durability;
+  qos_profile->reliability = /* (rmw_qos_reliability_policy_t) */ reliability;
+  qos_profile->durability = /* (rmw_qos_durability_policy_t) */ durability;
   qos_profile->deadline.sec = deadline_sec;
   qos_profile->deadline.nsec = deadline_nsec;
   qos_profile->lifespan.sec = lifespan_sec;
   qos_profile->lifespan.nsec = lifespan_nsec;
-  qos_profile->liveliness = (enum rmw_qos_liveliness_policy_t)liveliness;
+  qos_profile->liveliness = /* (rmw_qos_liveliness_policy_t) */ liveliness;
   qos_profile->liveliness_lease_duration.sec = liveliness_lease_duration_sec;
   qos_profile->liveliness_lease_duration.nsec = liveliness_lease_duration_nsec;
   qos_profile->avoid_ros_namespace_conventions = avoid_ros_namespace_conventions != 0;

--- a/rcldotnet/rcldotnet.h
+++ b/rcldotnet/rcldotnet.h
@@ -108,4 +108,26 @@ int32_t RCLDOTNET_CDECL native_rcl_send_response(void *service_handle, void *req
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_take_response(void *client_handle, void *request_header_handle, void *response_handle);
 
+RCLDOTNET_EXPORT
+int32_t RCLDOTNET_CDECL native_rcl_create_qos_profile_handle(void **qos_profile_handle);
+
+RCLDOTNET_EXPORT
+int32_t RCLDOTNET_CDECL native_rcl_destroy_qos_profile_handle(void *qos_profile_handle);
+
+RCLDOTNET_EXPORT
+int32_t RCLDOTNET_CDECL native_rcl_write_to_qos_profile_handle(
+    void *qos_profile_handle,
+    int32_t history,
+    int32_t depth,
+    int32_t reliability,
+    int32_t durability,
+    uint64_t deadline_sec,
+    uint64_t deadline_nsec,
+    uint64_t lifespan_sec,
+    uint64_t lifespan_nsec,
+    int32_t liveliness,
+    uint64_t liveliness_lease_duration_sec,
+    uint64_t liveliness_lease_duration_nsec,
+    int32_t /* bool */ avoid_ros_namespace_conventions);
+
 #endif // RCLDOTNET_H

--- a/rcldotnet/rcldotnet_node.c
+++ b/rcldotnet/rcldotnet_node.c
@@ -27,8 +27,11 @@
 
 int32_t native_rcl_create_publisher_handle(void **publisher_handle,
                                            void *node_handle, const char *topic,
-                                           void *typesupport) {
+                                           void *typesupport,
+                                           void *qos_profile_handle) {
   rcl_node_t *node = (rcl_node_t *)node_handle;
+
+  rmw_qos_profile_t *qos_profile = (rmw_qos_profile_t *)qos_profile_handle;
 
   rosidl_message_type_support_t *ts =
       (rosidl_message_type_support_t *)typesupport;
@@ -37,6 +40,11 @@ int32_t native_rcl_create_publisher_handle(void **publisher_handle,
       (rcl_publisher_t *)malloc(sizeof(rcl_publisher_t));
   *publisher = rcl_get_zero_initialized_publisher();
   rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();
+
+  if (qos_profile != NULL)
+  {
+    publisher_ops.qos = *qos_profile;
+  }
 
   rcl_ret_t ret =
       rcl_publisher_init(publisher, node, ts, topic, &publisher_ops);
@@ -59,8 +67,11 @@ int32_t native_rcl_destroy_publisher_handle(void *publisher_handle, void *node_h
 int32_t native_rcl_create_subscription_handle(void **subscription_handle,
                                               void *node_handle,
                                               const char *topic,
-                                              void *typesupport) {
+                                              void *typesupport,
+                                              void *qos_profile_handle) {
   rcl_node_t *node = (rcl_node_t *)node_handle;
+
+  rmw_qos_profile_t *qos_profile = (rmw_qos_profile_t *)qos_profile_handle;
 
   rosidl_message_type_support_t *ts =
       (rosidl_message_type_support_t *)typesupport;
@@ -70,6 +81,11 @@ int32_t native_rcl_create_subscription_handle(void **subscription_handle,
   *subscription = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_ops =
       rcl_subscription_get_default_options();
+
+  if (qos_profile != NULL)
+  {
+    subscription_ops.qos = *qos_profile;
+  }
 
   rcl_ret_t ret =
       rcl_subscription_init(subscription, node, ts, topic, &subscription_ops);

--- a/rcldotnet/rcldotnet_node.h
+++ b/rcldotnet/rcldotnet_node.h
@@ -20,6 +20,7 @@
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_create_publisher_handle(void **, void *,
                                                            const char *,
+                                                           void *,
                                                            void *);
 
 RCLDOTNET_EXPORT
@@ -28,6 +29,7 @@ int32_t RCLDOTNET_CDECL native_rcl_destroy_publisher_handle(void *publisher_hand
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_create_subscription_handle(void **, void *,
                                                               const char *,
+                                                              void *,
                                                               void *);
 
 RCLDOTNET_EXPORT


### PR DESCRIPTION
extracted from https://github.com/ros2-dotnet/ros2_dotnet/pull/94

Adds QoS basic settings to publisher and subscribers.

The default profiles (see https://github.com/ros2/rmw/blob/rolling/rmw/include/rmw/qos_profiles.h) are for another PR.

# Example

```C#
// taken and stripped down from https://github.com/schiller-de/tf2_dotnet/blob/main/tf2_dotnet/TransformListener.cs

var tf2ListenerQosProfile = QosProfile.KeepLast(100);

// The with methods return a immutable copy with the changed value.
var tf2StaticListenerQosProfile = QosProfile.KeepLast(100)
    .WithTransientLocal();

var tfSubscription = node.CreateSubscription<TFMessage>("/tf", (TFMessage message) =>
{
    // ...
}, tf2ListenerQosProfile);

var tfStaticSubscription = node.CreateSubscription<TFMessage>("/tf_static", (TFMessage message) =>
{
    // ...
}, tf2StaticListenerQosProfile);
```

# Added/changed public API
```C#
namespace ROS2
{
    public enum QosHistoryPolicy
    {
        SystemDefault = 0,
        KeepLast = 1,
        KeepAll = 2,
    }

    public enum QosReliabilityPolicy
    {
        SystemDefault = 0,
        Reliable = 1,
        BestEffort = 2,
    }

    public enum QosDurabilityPolicy
    {
        SystemDefault = 0,
        TransientLocal = 1,
        Volatile = 2,
    }

    public enum QosLivelinessPolicy
    {
        SystemDefault = 0,
        Automatic = 1,
        ManualByTopic = 3,
    }

    public sealed class QosProfile
    {
        // no default constructor
        private QosProfile() {}

        public static TimeSpan InfiniteDuration { get; }
        public static QosProfile DefaultProfile { get; }
        public QosHistoryPolicy History { get; }
        public int Depth { get; }
        public QosReliabilityPolicy Reliability { get; }
        public QosDurabilityPolicy Durability { get; }
        public TimeSpan Deadline { get; }
        public TimeSpan Lifespan { get; }
        public QosLivelinessPolicy Liveliness { get; }
        public TimeSpan LivelinessLeaseDuration { get; }
        public bool AvoidRosNamespaceConventions { get; }

        // factory methods
        public static QosProfile KeepLast(int depth);
        public static QosProfile KeepAll();

        // "immutable setters"
        public QosProfile WithKeepLast(int depth);
        public QosProfile WithKeepAll();

        public QosProfile WithReliability(QosReliabilityPolicy reliability);
        public QosProfile WithReliable();
        public QosProfile WithBestEffort();
	
        public QosProfile WithDurability(QosDurabilityPolicy durability);
	public QosProfile WithTransientLocal();
        public QosProfile WithVolatile();

        public QosProfile WithDeadline(TimeSpan deadline);
        public QosProfile WithLifespan(TimeSpan lifespan);

        public QosProfile WithLiveliness(QosLivelinessPolicy liveliness);
        public QosProfile WithLivelinessLeaseDuration(TimeSpan livelinessLeaseDuration);

        public QosProfile WithAvoidRosNamespaceConventions(bool avoidRosNamespaceConventions);
    }
}
```

```diff
 namespace ROS2
 {
     public sealed partial class Node
     {
-        public Publisher<T> CreatePublisher<T>(string topic) where T : IRosMessage
+        public Publisher<T> CreatePublisher<T>(string topic, QosProfile qosProfile = null) where T : IRosMessage

-        public Subscription<T> CreateSubscription<T>(string topic, Action<T> callback) where T : IRosMessage, new()
+        public Subscription<T> CreateSubscription<T>(string topic, Action<T> callback, QosProfile qosProfile = null) where T : IRosMessage, new()
     }
 }
```