### PR TITLE
Add iron to Linux CI

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -12,6 +12,7 @@ jobs:
         ros_distribution:
           - foxy
           - humble
+          - iron
           - rolling
         include:
           # Foxy Fitzroy (June 2020 - May 2023)
@@ -23,6 +24,11 @@ jobs:
           - os: ubuntu-22.04
             test_target_framework: net6.0
             ros_distribution: humble
+            ros_version: 2
+          # Iron Irwini (May 2023 - November 2024)
+          - os: ubuntu-22.04
+            test_target_framework: net6.0
+            ros_distribution: iron
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - os: ubuntu-22.04

--- a/ros2_dotnet_iron.repos
+++ b/ros2_dotnet_iron.repos
@@ -1,0 +1,37 @@
+repositories:
+  ament_dotnet/ament_cmake_export_assemblies:
+    type: git
+    url: https://github.com/ros2-dotnet/ament_cmake_export_assemblies.git
+    version: main
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: iron
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: iron
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: iron
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: iron
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: iron
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: iron
+  ros2_dotnet/dotnet_cmake_module:
+    type: git
+    url: https://github.com/ros2-dotnet/dotnet_cmake_module.git
+    version: main
+  ros2_dotnet/ros2_dotnet:
+    type: git
+    url: https://github.com/ros2-dotnet/ros2_dotnet.git
+    version: main


### PR DESCRIPTION
Let's support Iron from day one :)

https://www.openrobotics.org/blog/2023/5/23/ros-2-iron-irwini-released

depends on update from `ros-tooling/setup-ros`:
- https://github.com/ros-tooling/setup-ros/pull/568