### PR TITLE
fix Timers not being invoked when using ActionClients or ActionServer within the same node

### DIFF
--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -1221,6 +1221,14 @@ namespace ROS2
                     WaitSetAddGuardCondition(waitSetHandle, guardCondition.Handle);
                 }
 
+                // Add timers to WaitSet before action clients and servers.
+                // As ActionClient and ActionServer also register timers internally,
+                // the order of adding them to the WaitSet has to match the execution order 
+                foreach (var timer in node.Timers)
+                {
+                    WaitSetAddTimer(waitSetHandle, timer.Handle);
+                }
+
                 foreach (var actionClient in node.ActionClients)
                 {
                     WaitSetAddActionClient(waitSetHandle, actionClient.Handle);
@@ -1229,11 +1237,6 @@ namespace ROS2
                 foreach (var actionServer in node.ActionServers)
                 {
                     WaitSetAddActionServer(waitSetHandle, actionServer.Handle);
-                }
-
-                foreach (var timer in node.Timers)
-                {
-                    WaitSetAddTimer(waitSetHandle, timer.Handle);
                 }
 
                 bool ready = Wait(waitSetHandle, timeout);

--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -1221,14 +1221,17 @@ namespace ROS2
                     WaitSetAddGuardCondition(waitSetHandle, guardCondition.Handle);
                 }
 
-                // Add timers to WaitSet before action clients and servers.
-                // As ActionClient and ActionServer also register timers internally,
-                // the order of adding them to the WaitSet has to match the execution order 
                 foreach (var timer in node.Timers)
                 {
                     WaitSetAddTimer(waitSetHandle, timer.Handle);
                 }
 
+                // Action clients and servers need to be registerd after all the
+                // others that are handled by
+                // RCLdotnetDelegates.native_rcl_wait_set_*_ready methods, as
+                // they track indexes of the given waitables. Adding action
+                // clients and action servers before will get those indexes
+                // mixed up.
                 foreach (var actionClient in node.ActionClients)
                 {
                     WaitSetAddActionClient(waitSetHandle, actionClient.Handle);


### PR DESCRIPTION
currently when running a node that creates an ActionClient or ActionServer, creating a Timer in the same node will just not execute the timer callback at all as it tries to execute the timer at index 0, but ActionClient and ActionServer add their Timers to the WaitSet first.