### PR TITLE
Configurable ROS2 initialization arguments and perhaps native subdirectory path library loading?

### DIFF
--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -1470,14 +1470,29 @@ namespace ROS2
             }
         }
 
+        /// <summary>
+        /// Initialize ROS2 with app's launch arguments.
+        /// </summary>
         public static void Init()
+        {
+            string[] args = System.Environment.GetCommandLineArgs();
+            Init(args);
+        }
+
+        /// <summary>
+        /// Initialize ROS2 with supplied arguments.
+        /// </summary>
+        /// <remarks>
+        /// This is overloaded so that it can support arguments set up during run-time.
+        /// </remarks>
+        /// <param name="args">ROS2 arguments to pass along.</param>
+        public static void Init(string[] args)
         {
             lock (syncLock)
             {
                 if (!initialized)
                 {
-                    string[] args = System.Environment.GetCommandLineArgs();
-                    RCLRet ret = RCLdotnetDelegates.native_rcl_init(args.Length, args);
+                    RCLRet ret = RCLdotnetDelegates.native_rcl_init(args.Length, args.Length <= 0 ? null : args);
                     RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(RCLdotnetDelegates.native_rcl_init)}() failed.");
                     initialized = true;
                 }

--- a/rcldotnet_common/DllLoadUtils.cs
+++ b/rcldotnet_common/DllLoadUtils.cs
@@ -16,6 +16,7 @@
 // Based on http://dimitry-i.blogspot.com.es/2013/01/mononet-how-to-dynamically-load-native.html
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace ROS2
@@ -195,6 +196,8 @@ namespace ROS2
                 IntPtr nativeFunctionPointer = GetProcAddress(nativeLibrary, nativeFunctionName);
                 functionDelegate = (FunctionType)Marshal.GetDelegateForFunctionPointer(nativeFunctionPointer, typeof(FunctionType));
             }
+
+            public const string AssemblyDirectory = "ros2";
         }
 
         public class DllLoadUtilsUWP : DllLoadUtilsAbs
@@ -215,7 +218,7 @@ namespace ROS2
 
             public override IntPtr LoadLibrary(string fileName)
             {
-                string libraryName = fileName + "_native.dll";
+                string libraryName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AssemblyDirectory, fileName + "_native.dll");
                 IntPtr ptr = LoadPackagedLibraryUWP(libraryName);
                 if (ptr == IntPtr.Zero)
                 {
@@ -227,6 +230,9 @@ namespace ROS2
 
         public class DllLoadUtilsWindowsDesktop : DllLoadUtilsAbs
         {
+
+            [DllImport("kernel32.dll", EntryPoint = "GetLastError", SetLastError = true, ExactSpelling = true)]
+            private static extern int GetLastError();
 
             [DllImport("kernel32.dll", EntryPoint = "LoadLibraryA", SetLastError = true, ExactSpelling = true)]
             private static extern IntPtr LoadLibraryA(string fileName, int reserved = 0);
@@ -243,7 +249,7 @@ namespace ROS2
 
             public override IntPtr LoadLibrary(string fileName)
             {
-                string libraryName = fileName + "_native.dll";
+                string libraryName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AssemblyDirectory, fileName + "_native.dll");
                 IntPtr ptr = LoadLibraryA(libraryName);
                 if (ptr == IntPtr.Zero)
                 {
@@ -287,7 +293,7 @@ namespace ROS2
 
             public override IntPtr LoadLibrary(string fileName)
             {
-                string libraryName = "lib" + fileName + "_native.so";
+                string libraryName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AssemblyDirectory, "lib" + fileName + "_native.so");
                 IntPtr ptr = dlopen(libraryName, RTLD_NOW);
                 if (ptr == IntPtr.Zero)
                 {
@@ -334,7 +340,7 @@ namespace ROS2
 
             public override IntPtr LoadLibrary(string fileName)
             {
-                string libraryName = "lib" + fileName + "_native.dylib";
+                string libraryName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AssemblyDirectory, "lib" + fileName + "_native.dylib");
                 IntPtr ptr = dlopen(libraryName, RTLD_NOW);
                 if (ptr == IntPtr.Zero)
                 {


### PR DESCRIPTION
This was simple,
1. A better configuration for ROS2 initialization arguments,
1. For Windows, to better organize the dynamic-linked ROS2 binaries in a subfolder in case of a tooling app.

So,
- [x] Followed ROS2 initialization by overloading `Init()` method for `args`,
- [x] Added Path combining in DllLoadUtils for subfolder with constant name. (& Absolute Path-ing)

You can choose not to include the library loading part, but the initialization part is better because if you're running the executable from CMD/PowerShell, the `args[0]` will be the executable path.